### PR TITLE
feat: 이미지 상세 페이지·업로드 모달·비로그인 유도 모달 추가 및 좋아요·네비 회귀 픽스

### DIFF
--- a/front-react/src/api/images.ts
+++ b/front-react/src/api/images.ts
@@ -1,11 +1,15 @@
+import axios from 'axios';
 import { axiosClient } from '@/lib/axios';
 import type {
+  ImageDetailResponse,
   ImageItem,
   ImageLikeResponse,
   ImagePage,
+  ImageUploadCompleteRequest,
   Provider,
   SortKey,
   TopLikeResponse,
+  UploadUrlResponse,
 } from '@/types';
 
 export interface ListImagesParams {
@@ -60,4 +64,23 @@ export const imagesApi = {
     axiosClient
       .get<ImagePage>('/images', { params: { page: 0, size, sort: 'popular' } })
       .then((r) => r.data.content),
+
+  getById: (imageId: string): Promise<ImageDetailResponse> =>
+    axiosClient.get<ImageDetailResponse>(`/images/${imageId}`).then((r) => r.data),
+
+  requestUploadUrl: (filename: string): Promise<UploadUrlResponse> =>
+    axiosClient
+      .get<UploadUrlResponse>('/images/upload', { params: { filename } })
+      .then((r) => r.data),
+
+  completeUpload: (payload: ImageUploadCompleteRequest): Promise<ImageDetailResponse> =>
+    axiosClient.post<ImageDetailResponse>('/images', payload).then((r) => r.data),
+
+  // S3 presigned URL 에 PUT 으로 직접 업로드한다. 인증 헤더가 안 가도록 별도 axios 인스턴스 사용.
+  uploadToS3: (uploadUrl: string, file: File): Promise<void> =>
+    axios
+      .put(uploadUrl, file, {
+        headers: { 'Content-Type': 'application/octet-stream' },
+      })
+      .then(() => undefined),
 };

--- a/front-react/src/components/common/AuthPromptModal.tsx
+++ b/front-react/src/components/common/AuthPromptModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { X, Heart } from 'lucide-react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  message?: string;
+}
+
+export function AuthPromptModal({ open, onClose, message }: Props) {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const from = location.pathname + location.search;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="auth-prompt-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative w-full max-w-sm rounded-[16px] border border-[var(--border-default)] bg-elevated p-6 shadow-2xl">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className="absolute right-3 top-3 text-text-tertiary hover:text-text-primary p-1.5 rounded-md hover:bg-white/[0.06] transition-colors"
+        >
+          <X size={16} />
+        </button>
+
+        <div className="flex flex-col items-center text-center">
+          <div className="w-12 h-12 rounded-full bg-[rgba(239,68,68,0.12)] flex items-center justify-center mb-4">
+            <Heart size={22} className="text-[var(--like)]" />
+          </div>
+          <h2 id="auth-prompt-title" className="text-lg font-semibold tracking-tight">
+            로그인이 필요해요
+          </h2>
+          <p className="text-sm text-text-secondary mt-2">
+            {message ?? '계속하려면 로그인하거나 가입해주세요.'}
+          </p>
+
+          <div className="w-full mt-6 space-y-2">
+            <Link
+              to="/member/login"
+              state={{ from }}
+              className="nm-btn nm-btn--primary nm-btn--lg w-full"
+              onClick={onClose}
+            >
+              로그인
+            </Link>
+            <Link
+              to="/member/join"
+              className="nm-btn nm-btn--outline nm-btn--lg w-full"
+              onClick={onClose}
+            >
+              회원가입
+            </Link>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="mt-4 text-xs text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            나중에 할게요
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-react/src/components/common/GlobalModals.tsx
+++ b/front-react/src/components/common/GlobalModals.tsx
@@ -1,0 +1,22 @@
+import { AuthPromptModal } from './AuthPromptModal';
+import { UploadModal } from '@/components/upload/UploadModal';
+import { useUIStore } from '@/stores/uiStore';
+
+export function GlobalModals() {
+  const authPromptOpen = useUIStore((s) => s.authPromptOpen);
+  const authPromptMessage = useUIStore((s) => s.authPromptMessage);
+  const closeAuthPrompt = useUIStore((s) => s.closeAuthPrompt);
+  const uploadOpen = useUIStore((s) => s.uploadOpen);
+  const closeUpload = useUIStore((s) => s.closeUpload);
+
+  return (
+    <>
+      <AuthPromptModal
+        open={authPromptOpen}
+        onClose={closeAuthPrompt}
+        message={authPromptMessage ?? undefined}
+      />
+      <UploadModal open={uploadOpen} onClose={closeUpload} />
+    </>
+  );
+}

--- a/front-react/src/components/gallery/CurationHero.tsx
+++ b/front-react/src/components/gallery/CurationHero.tsx
@@ -1,4 +1,5 @@
 import { Heart, Eye } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { useLikeToggle } from '@/hooks/useLikeToggle';
 import type { ImageItem } from '@/types';
@@ -131,7 +132,11 @@ function BentoTile({ image, span, hero }: TileProps) {
   const liked = image.likeState ?? false;
   const thumbnail = image.url ?? image.thumbnailUrl ?? '';
   return (
-    <div className={cn('cat-card ap-tile', `ap-tile--${span}`)} style={spanGridStyle[span]}>
+    <Link
+      to={`/images/${image.id}`}
+      className={cn('cat-card ap-tile block', `ap-tile--${span}`)}
+      style={spanGridStyle[span]}
+    >
       <img src={thumbnail} alt={image.name ?? ''} loading="lazy" />
       <div className="ap-tile-shade" />
       <div className="cc-overlay-top">
@@ -181,7 +186,7 @@ function BentoTile({ image, span, hero }: TileProps) {
           )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/front-react/src/components/gallery/ImageCard.tsx
+++ b/front-react/src/components/gallery/ImageCard.tsx
@@ -1,4 +1,5 @@
 import { Heart, Eye } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { useLikeToggle } from '@/hooks/useLikeToggle';
 import type { ImageItem } from '@/types';
@@ -16,8 +17,9 @@ export function ImageCard({ image, aspectRatio, showViews }: Props) {
   const title = image.name ?? '이름 없음';
 
   return (
-    <div
-      className="cat-card"
+    <Link
+      to={`/images/${image.id}`}
+      className="cat-card block"
       style={aspectRatio ? { aspectRatio: `1 / ${aspectRatio}` } : undefined}
     >
       <img src={thumbnail} alt={title} loading="lazy" />
@@ -55,7 +57,7 @@ export function ImageCard({ image, aspectRatio, showViews }: Props) {
           )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/front-react/src/components/layout/Sidebar.tsx
+++ b/front-react/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   PanelLeftOpen,
   Upload,
   ChevronsUpDown,
+  LogIn,
 } from 'lucide-react';
 import { NmLogo } from '@/components/icons/NmLogoMark';
 import { useAuthStore } from '@/stores/authStore';
@@ -40,45 +41,40 @@ export function Sidebar({ collapsed, onToggle }: Props) {
     openUpload();
   };
 
-  if (collapsed) {
-    return (
-      <aside className="h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out w-[48px] shrink-0">
-        <div className="flex items-center justify-center h-[60px] shrink-0">
-          <button
-            type="button"
-            onClick={onToggle}
-            className="text-text-secondary hover:text-text-primary p-1.5 rounded-md hover:bg-white/[0.04] transition-colors"
-            aria-label="사이드바 펼치기"
-          >
-            <PanelLeftOpen size={16} />
-          </button>
-        </div>
-      </aside>
-    );
-  }
-
   return (
-    <aside className="h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out w-[244px]">
-      <div className="flex items-center justify-between px-3 h-[60px] border-b border-[var(--border-subtle)] shrink-0">
-        <NmLogo />
+    <aside
+      className={cn(
+        'h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out shrink-0',
+        collapsed ? 'w-[60px]' : 'w-[244px]',
+      )}
+    >
+      <div
+        className={cn(
+          'flex items-center h-[60px] border-b border-[var(--border-subtle)] shrink-0',
+          collapsed ? 'justify-center' : 'justify-between px-3',
+        )}
+      >
+        {!collapsed && <NmLogo />}
         <button
           type="button"
           onClick={onToggle}
           className="text-text-secondary hover:text-text-primary p-1.5 rounded-md hover:bg-white/[0.04] transition-colors"
-          aria-label="사이드바 접기"
+          aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
         >
-          <PanelLeftClose size={16} />
+          {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
         </button>
       </div>
 
-      <div className="px-3 pt-4">
+      <div className={cn('pt-4', collapsed ? 'px-0 flex justify-center' : 'px-3')}>
         <button
           type="button"
           onClick={handleUploadClick}
-          className="nm-btn nm-btn--primary w-full"
+          title="사진 올리기"
+          aria-label="사진 올리기"
+          className={cn('nm-btn nm-btn--primary', collapsed ? 'nm-btn--icon' : 'w-full')}
         >
           <Upload size={16} />
-          <span>사진 올리기</span>
+          {!collapsed && <span>사진 올리기</span>}
         </button>
       </div>
 
@@ -89,14 +85,23 @@ export function Sidebar({ collapsed, onToggle }: Props) {
             return (
               <span
                 key={item.label}
-                className="flex items-center gap-3 rounded-md px-3 h-9 text-sm text-text-tertiary cursor-not-allowed"
+                title={item.label}
+                aria-label={item.label}
+                className={cn(
+                  'flex items-center rounded-md h-9 text-sm text-text-tertiary cursor-not-allowed',
+                  collapsed ? 'justify-center' : 'gap-3 px-3',
+                )}
               >
                 <Icon size={18} />
-                <span className="flex-1">{item.label}</span>
-                {item.badge && (
-                  <span className="text-[11px] font-medium px-1.5 rounded bg-elevated text-text-secondary">
-                    {item.badge}
-                  </span>
+                {!collapsed && (
+                  <>
+                    <span className="flex-1">{item.label}</span>
+                    {item.badge && (
+                      <span className="text-[11px] font-medium px-1.5 rounded bg-elevated text-text-secondary">
+                        {item.badge}
+                      </span>
+                    )}
+                  </>
                 )}
               </span>
             );
@@ -105,9 +110,12 @@ export function Sidebar({ collapsed, onToggle }: Props) {
             <NavLink
               key={item.to}
               to={item.to}
+              title={item.label}
+              aria-label={item.label}
               className={({ isActive }) =>
                 cn(
-                  'flex items-center gap-3 rounded-md px-3 h-9 text-sm transition-colors',
+                  'flex items-center rounded-md h-9 text-sm transition-colors',
+                  collapsed ? 'justify-center' : 'gap-3 px-3',
                   isActive
                     ? 'bg-accent text-accent-bright'
                     : 'text-text-secondary hover:bg-white/[0.04] hover:text-text-primary',
@@ -115,32 +123,46 @@ export function Sidebar({ collapsed, onToggle }: Props) {
               }
             >
               <Icon size={18} />
-              <span className="flex-1">{item.label}</span>
+              {!collapsed && <span className="flex-1">{item.label}</span>}
             </NavLink>
           );
         })}
       </nav>
 
-      <div className="border-t border-[var(--border-subtle)] p-3">
+      <div className={cn('border-t border-[var(--border-subtle)]', collapsed ? 'p-2 flex justify-center' : 'p-3')}>
         {member ? (
           <NavLink
             to="/member/info"
-            className="flex items-center gap-3 rounded-md px-2 h-12 hover:bg-white/[0.04]"
+            title={member.nickname ?? '내 정보'}
+            aria-label="내 정보"
+            className={cn(
+              'flex items-center rounded-md hover:bg-white/[0.04]',
+              collapsed ? 'justify-center w-9 h-9' : 'gap-3 px-2 h-12',
+            )}
           >
             <div className="w-8 h-8 rounded-full bg-elevated flex items-center justify-center text-sm font-semibold shrink-0">
               {member.nickname?.[0] ?? '?'}
             </div>
-            <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium truncate">{member.nickname}</div>
-              <div className="text-[11px] text-text-tertiary truncate font-en">
-                {member.email}
-              </div>
-            </div>
-            <ChevronsUpDown size={14} className="text-text-tertiary" />
+            {!collapsed && (
+              <>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{member.nickname}</div>
+                  <div className="text-[11px] text-text-tertiary truncate font-en">
+                    {member.email}
+                  </div>
+                </div>
+                <ChevronsUpDown size={14} className="text-text-tertiary" />
+              </>
+            )}
           </NavLink>
         ) : (
-          <NavLink to="/member/login" className="nm-btn nm-btn--outline w-full">
-            로그인
+          <NavLink
+            to="/member/login"
+            title="로그인"
+            aria-label="로그인"
+            className={cn('nm-btn nm-btn--outline', collapsed ? 'nm-btn--icon' : 'w-full')}
+          >
+            {collapsed ? <LogIn size={16} /> : '로그인'}
           </NavLink>
         )}
       </div>

--- a/front-react/src/components/layout/Sidebar.tsx
+++ b/front-react/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   Upload,
   ChevronsUpDown,
 } from 'lucide-react';
-import { NmLogo, NmLogoMark } from '@/components/icons/NmLogoMark';
+import { NmLogo } from '@/components/icons/NmLogoMark';
 import { useAuthStore } from '@/stores/authStore';
 import { useUIStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
@@ -40,27 +40,34 @@ export function Sidebar({ collapsed, onToggle }: Props) {
     openUpload();
   };
 
+  if (collapsed) {
+    return (
+      <aside className="h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out w-[48px] shrink-0">
+        <div className="flex items-center justify-center h-[60px] shrink-0">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="text-text-secondary hover:text-text-primary p-1.5 rounded-md hover:bg-white/[0.04] transition-colors"
+            aria-label="사이드바 펼치기"
+          >
+            <PanelLeftOpen size={16} />
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
   return (
-    <aside
-      className={cn(
-        'h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out',
-        collapsed ? 'w-[64px]' : 'w-[244px]',
-      )}
-    >
-      <div
-        className={cn(
-          'flex items-center px-3 h-[60px] border-b border-[var(--border-subtle)] shrink-0',
-          collapsed ? 'justify-center' : 'justify-between',
-        )}
-      >
-        {collapsed ? <NmLogoMark /> : <NmLogo />}
+    <aside className="h-screen flex flex-col border-r border-[var(--border-subtle)] bg-surface transition-[width] duration-200 ease-out w-[244px]">
+      <div className="flex items-center justify-between px-3 h-[60px] border-b border-[var(--border-subtle)] shrink-0">
+        <NmLogo />
         <button
           type="button"
           onClick={onToggle}
           className="text-text-secondary hover:text-text-primary p-1.5 rounded-md hover:bg-white/[0.04] transition-colors"
-          aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+          aria-label="사이드바 접기"
         >
-          {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+          <PanelLeftClose size={16} />
         </button>
       </div>
 
@@ -68,14 +75,10 @@ export function Sidebar({ collapsed, onToggle }: Props) {
         <button
           type="button"
           onClick={handleUploadClick}
-          className={cn(
-            'nm-btn nm-btn--primary w-full',
-            collapsed && 'nm-btn--icon',
-          )}
-          title="사진 올리기"
+          className="nm-btn nm-btn--primary w-full"
         >
           <Upload size={16} />
-          {!collapsed && <span>사진 올리기</span>}
+          <span>사진 올리기</span>
         </button>
       </div>
 
@@ -86,22 +89,14 @@ export function Sidebar({ collapsed, onToggle }: Props) {
             return (
               <span
                 key={item.label}
-                title={item.label}
-                className={cn(
-                  'flex items-center gap-3 rounded-md px-3 h-9 text-sm text-text-tertiary cursor-not-allowed',
-                  collapsed && 'justify-center px-0',
-                )}
+                className="flex items-center gap-3 rounded-md px-3 h-9 text-sm text-text-tertiary cursor-not-allowed"
               >
                 <Icon size={18} />
-                {!collapsed && (
-                  <>
-                    <span className="flex-1">{item.label}</span>
-                    {item.badge && (
-                      <span className="text-[11px] font-medium px-1.5 rounded bg-elevated text-text-secondary">
-                        {item.badge}
-                      </span>
-                    )}
-                  </>
+                <span className="flex-1">{item.label}</span>
+                {item.badge && (
+                  <span className="text-[11px] font-medium px-1.5 rounded bg-elevated text-text-secondary">
+                    {item.badge}
+                  </span>
                 )}
               </span>
             );
@@ -110,11 +105,9 @@ export function Sidebar({ collapsed, onToggle }: Props) {
             <NavLink
               key={item.to}
               to={item.to}
-              title={item.label}
               className={({ isActive }) =>
                 cn(
                   'flex items-center gap-3 rounded-md px-3 h-9 text-sm transition-colors',
-                  collapsed && 'justify-center px-0',
                   isActive
                     ? 'bg-accent text-accent-bright'
                     : 'text-text-secondary hover:bg-white/[0.04] hover:text-text-primary',
@@ -122,7 +115,7 @@ export function Sidebar({ collapsed, onToggle }: Props) {
               }
             >
               <Icon size={18} />
-              {!collapsed && <span className="flex-1">{item.label}</span>}
+              <span className="flex-1">{item.label}</span>
             </NavLink>
           );
         })}
@@ -132,35 +125,23 @@ export function Sidebar({ collapsed, onToggle }: Props) {
         {member ? (
           <NavLink
             to="/member/info"
-            className={cn(
-              'flex items-center gap-3 rounded-md px-2 h-12 hover:bg-white/[0.04]',
-              collapsed && 'justify-center px-0',
-            )}
+            className="flex items-center gap-3 rounded-md px-2 h-12 hover:bg-white/[0.04]"
           >
             <div className="w-8 h-8 rounded-full bg-elevated flex items-center justify-center text-sm font-semibold shrink-0">
               {member.nickname?.[0] ?? '?'}
             </div>
-            {!collapsed && (
-              <>
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium truncate">{member.nickname}</div>
-                  <div className="text-[11px] text-text-tertiary truncate font-en">
-                    {member.email}
-                  </div>
-                </div>
-                <ChevronsUpDown size={14} className="text-text-tertiary" />
-              </>
-            )}
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium truncate">{member.nickname}</div>
+              <div className="text-[11px] text-text-tertiary truncate font-en">
+                {member.email}
+              </div>
+            </div>
+            <ChevronsUpDown size={14} className="text-text-tertiary" />
           </NavLink>
         ) : (
-          !collapsed && (
-            <NavLink
-              to="/member/login"
-              className="nm-btn nm-btn--outline w-full"
-            >
-              로그인
-            </NavLink>
-          )
+          <NavLink to="/member/login" className="nm-btn nm-btn--outline w-full">
+            로그인
+          </NavLink>
         )}
       </div>
     </aside>

--- a/front-react/src/components/layout/Sidebar.tsx
+++ b/front-react/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { NmLogo, NmLogoMark } from '@/components/icons/NmLogoMark';
 import { useAuthStore } from '@/stores/authStore';
+import { useUIStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
 
 interface Props {
@@ -27,6 +28,17 @@ const navItems = [
 
 export function Sidebar({ collapsed, onToggle }: Props) {
   const member = useAuthStore((s) => s.member);
+  const isLogin = useAuthStore((s) => s.isLogin);
+  const openUpload = useUIStore((s) => s.openUpload);
+  const openAuthPrompt = useUIStore((s) => s.openAuthPrompt);
+
+  const handleUploadClick = () => {
+    if (!isLogin) {
+      openAuthPrompt('사진 업로드는 로그인 후 이용할 수 있어요.');
+      return;
+    }
+    openUpload();
+  };
 
   return (
     <aside
@@ -55,6 +67,7 @@ export function Sidebar({ collapsed, onToggle }: Props) {
       <div className="px-3 pt-4">
         <button
           type="button"
+          onClick={handleUploadClick}
           className={cn(
             'nm-btn nm-btn--primary w-full',
             collapsed && 'nm-btn--icon',

--- a/front-react/src/components/upload/UploadModal.tsx
+++ b/front-react/src/components/upload/UploadModal.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Image as ImageIcon, Repeat2, Upload, X, Clock, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { imagesApi } from '@/api/images';
+import { useAuthStore } from '@/stores/authStore';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const MAX_DESCRIPTION = 500;
+const SUGGESTED_TAGS = ['#아기냥', '#식빵자세', '#골골송', '#창문냥', '#박스고양이', '#하품'];
+
+function bytesToReadable(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function normalizeTag(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^#+/, '');
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export function UploadModal({ open, onClose }: Props) {
+  const isLogin = useAuthStore((s) => s.isLogin);
+  const qc = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetForm = useCallback(() => {
+    setFile(null);
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return null;
+    });
+    setDescription('');
+    setTags([]);
+    setTagInput('');
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isSubmitting) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [open, onClose, isSubmitting]);
+
+  useEffect(() => {
+    if (!open) resetForm();
+  }, [open, resetForm]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const handleFileSelect = (selected: File | null) => {
+    if (!selected) return;
+    if (!selected.type.startsWith('image/')) {
+      toast.warning('이미지 파일만 올릴 수 있어요.');
+      return;
+    }
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return URL.createObjectURL(selected);
+    });
+    setFile(selected);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const dropped = e.dataTransfer.files?.[0];
+    if (dropped) handleFileSelect(dropped);
+  };
+
+  const addTag = (raw: string) => {
+    const normalized = normalizeTag(raw);
+    if (!normalized) return;
+    setTags((current) =>
+      current.includes(normalized) || current.length >= 10
+        ? current
+        : [...current, normalized],
+    );
+    setTagInput('');
+  };
+
+  const removeTag = (t: string) => {
+    setTags((current) => current.filter((x) => x !== t));
+  };
+
+  const handleTagKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if ((e.key === 'Enter' || e.key === ',' || e.key === ' ') && tagInput.trim()) {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput && tags.length > 0) {
+      setTags((current) => current.slice(0, -1));
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!isLogin) {
+      toast.warning('로그인이 필요해요.');
+      return;
+    }
+    if (!file) {
+      toast.warning('사진을 먼저 선택해주세요.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const { id, uploadUrl } = await imagesApi.requestUploadUrl(file.name);
+      await imagesApi.uploadToS3(uploadUrl, file);
+      await imagesApi.completeUpload({
+        imageId: id,
+        description: description.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      });
+      toast.success('사진이 올라갔어요. 90일 카운트다운이 시작됐어요.');
+      await qc.invalidateQueries({ queryKey: ['images', 'list'], exact: false });
+      await qc.invalidateQueries({ queryKey: ['images', 'popular'], exact: false });
+      await qc.invalidateQueries({ queryKey: ['images', 'topLike'] });
+      onClose();
+    } catch (err) {
+      // axios 인터셉터가 토스트, 여기는 상태만 복구
+      console.error(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const remainingDescription = MAX_DESCRIPTION - description.length;
+  const previewMeta = useMemo(() => {
+    if (!file) return null;
+    return `${bytesToReadable(file.size)}`;
+  }, [file]);
+
+  if (!open) return null;
+
+  const isEmpty = !file;
+
+  return (
+    <div
+      className="up-root"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="upload-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isSubmitting) onClose();
+      }}
+    >
+      <div className={cn('up-modal', isEmpty && 'up-modal--empty')}>
+        <header className="up-header">
+          <div>
+            <h2 id="upload-title" className="up-title">사진 올리기</h2>
+            <p className="up-subtitle">
+              올리는 순간 <em>90일 카운트다운</em>이 시작됩니다. 좋아요 50개를 받으면 영원히 남습니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="up-close"
+            aria-label="닫기"
+            onClick={onClose}
+            disabled={isSubmitting}
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        {isEmpty ? (
+          <div className="up-empty">
+            <div
+              className={cn('up-empty-zone', isDragging && 'is-dragging')}
+              onClick={() => fileInputRef.current?.click()}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                }
+              }}
+            >
+              <div className="up-empty-icon">
+                <Upload />
+              </div>
+              <h3 className="up-empty-title">사진을 끌어다 놓으세요</h3>
+              <p className="up-empty-sub">
+                또는 클릭해서 파일을 선택할 수 있어요. JPG · PNG · WebP
+              </p>
+              <button
+                type="button"
+                className="nm-btn nm-btn--primary nm-btn--lg"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  fileInputRef.current?.click();
+                }}
+              >
+                <ImageIcon size={16} /> 사진 선택
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="up-body">
+            <section className="up-preview">
+              <div className="up-dropzone">
+                {previewUrl && (
+                  <img src={previewUrl} alt="" className="up-preview-img" />
+                )}
+                <div className="up-preview-shade" />
+                <button
+                  type="button"
+                  className="up-preview-replace"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Repeat2 /> 다른 사진으로 교체
+                </button>
+                <div className="up-preview-info">
+                  <div className="up-preview-name">{file?.name}</div>
+                  <div className="up-preview-meta">{previewMeta}</div>
+                </div>
+              </div>
+            </section>
+
+            <section className="up-form nm-scroll">
+              <div className="up-field">
+                <label className="up-label" htmlFor="up-tags">
+                  태그 <span className="up-label-opt">선택 · 최대 10개</span>
+                </label>
+                <div className="up-tags-input">
+                  {tags.map((t) => (
+                    <span key={t} className="up-tag">
+                      #{t}
+                      <button
+                        type="button"
+                        onClick={() => removeTag(t)}
+                        aria-label={`${t} 태그 제거`}
+                      >
+                        <X />
+                      </button>
+                    </span>
+                  ))}
+                  <input
+                    id="up-tags"
+                    className="up-tag-field"
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagKey}
+                    placeholder={tags.length === 0 ? '#아기냥, #자연광 처럼' : ''}
+                  />
+                </div>
+                <div className="up-suggest">
+                  {SUGGESTED_TAGS.filter((s) => !tags.includes(s.replace(/^#/, ''))).map(
+                    (s) => (
+                      <button
+                        type="button"
+                        key={s}
+                        className="up-suggest-chip"
+                        onClick={() => addTag(s)}
+                      >
+                        {s}
+                      </button>
+                    ),
+                  )}
+                </div>
+              </div>
+
+              <div className="up-field">
+                <label className="up-label" htmlFor="up-desc">
+                  설명 <span className="up-label-opt">선택</span>
+                </label>
+                <textarea
+                  id="up-desc"
+                  className="up-textarea"
+                  rows={4}
+                  maxLength={MAX_DESCRIPTION}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="이 순간에 대한 이야기를 적어보세요."
+                />
+                <span className="up-counter">
+                  {remainingDescription} / {MAX_DESCRIPTION}
+                </span>
+              </div>
+
+              <div className="up-notice">
+                <AlertTriangle className="up-notice-icon" />
+                <div className="up-notice-text">
+                  <strong>업로드 안내</strong>
+                  <br />
+                  업로드 후 90일 안에 좋아요 50개를 받으면 영구 보관됩니다. 그렇지 않으면 자동으로 삭제돼요.
+                </div>
+              </div>
+            </section>
+          </div>
+        )}
+
+        <footer className="up-footer">
+          <div className="up-clock">
+            <span className="up-clock-dot" aria-hidden="true" />
+            <span className="up-clock-text">
+              <Clock size={12} style={{ display: 'inline', verticalAlign: '-2px', marginRight: 4 }} />
+              올리면 <em>D-90</em> 카운트다운 시작
+            </span>
+          </div>
+          <div className="up-footer-right">
+            <button
+              type="button"
+              className="nm-btn nm-btn--ghost"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              className="nm-btn nm-btn--primary"
+              onClick={handleSubmit}
+              disabled={!file || isSubmitting}
+            >
+              <Upload size={14} />
+              {isSubmitting ? '올리는 중...' : '올리기'}
+            </button>
+          </div>
+        </footer>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const selected = e.target.files?.[0] ?? null;
+            handleFileSelect(selected);
+            e.target.value = '';
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front-react/src/hooks/useImageDetail.ts
+++ b/front-react/src/hooks/useImageDetail.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { imagesApi } from '@/api/images';
+import type { ImageDetailResponse, ImagePage } from '@/types';
+
+export function useImageDetail(imageId: string | undefined) {
+  return useQuery<ImageDetailResponse>({
+    queryKey: ['images', 'detail', imageId],
+    enabled: Boolean(imageId),
+    queryFn: () => imagesApi.getById(imageId!),
+    staleTime: 30_000,
+  });
+}
+
+// 갤러리 리스트 캐시를 그대로 활용해서 현재 위치/이웃 ID를 계산한다.
+export function useGalleryNeighbors(imageId: string | undefined) {
+  const qc = useQueryClient();
+
+  return useMemo(() => {
+    const empty = {
+      prev: null as string | null,
+      next: null as string | null,
+      position: null as { index: number; total: number } | null,
+    };
+    if (!imageId) return empty;
+
+    const listCaches = qc.getQueriesData<{ pages: ImagePage[] }>({
+      queryKey: ['images', 'list'],
+      exact: false,
+    });
+    for (const [, data] of listCaches) {
+      if (!data) continue;
+      const flat = data.pages.flatMap((p) => p.content);
+      const idx = flat.findIndex((img) => img.id === imageId);
+      if (idx >= 0) {
+        return {
+          prev: idx > 0 ? flat[idx - 1].id : null,
+          next: idx < flat.length - 1 ? flat[idx + 1].id : null,
+          position: { index: idx + 1, total: flat.length },
+        };
+      }
+    }
+    return empty;
+  }, [imageId, qc]);
+}

--- a/front-react/src/hooks/useLikeToggle.ts
+++ b/front-react/src/hooks/useLikeToggle.ts
@@ -1,8 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 import { imagesApi } from '@/api/images';
 import { useAuthStore } from '@/stores/authStore';
-import type { ImageItem, ImageLikeResponse, ImagePage } from '@/types';
+import { useUIStore } from '@/stores/uiStore';
+import type {
+  ImageDetailResponse,
+  ImageItem,
+  ImageLikeResponse,
+  ImagePage,
+} from '@/types';
 
 function buildSetter(imageId: string, nextLiked: boolean | null) {
   return (img: ImageItem): ImageItem => {
@@ -51,16 +56,32 @@ function applyToCaches(
       imageInfo: setter(topLike.imageInfo),
     });
   }
+
+  qc.getQueriesData<ImageDetailResponse>({
+    queryKey: ['images', 'detail'],
+    exact: false,
+  }).forEach(([key, data]) => {
+    if (!data || data.id !== imageId) return;
+    const wasLiked = data.likeState;
+    const target = nextLiked ?? !wasLiked;
+    if (wasLiked === target) return;
+    qc.setQueryData(key, {
+      ...data,
+      likeState: target,
+      likesCount: data.likesCount + (target ? 1 : -1),
+    });
+  });
 }
 
 export function useLikeToggle() {
   const qc = useQueryClient();
   const isLogin = useAuthStore((s) => s.isLogin);
+  const openAuthPrompt = useUIStore((s) => s.openAuthPrompt);
 
   return useMutation<ImageLikeResponse, Error, string>({
     mutationFn: (imageId) => {
       if (!isLogin) {
-        toast.warning('로그인이 필요해요.');
+        openAuthPrompt('좋아요는 로그인 후 이용할 수 있어요.');
         return Promise.reject(new Error('UNAUTHENTICATED'));
       }
       return imagesApi.toggleLike(imageId);

--- a/front-react/src/index.css
+++ b/front-react/src/index.css
@@ -1,5 +1,7 @@
 @import './styles/tokens.css';
 @import './styles/atoms.css';
+@import './styles/detail.css';
+@import './styles/upload.css';
 
 @tailwind base;
 @tailwind components;

--- a/front-react/src/pages/ImageDetail.tsx
+++ b/front-react/src/pages/ImageDetail.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useMemo } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  Eye,
+  Flag,
+  Heart,
+  Maximize2,
+  MessageSquareText,
+  Share2,
+  Bookmark,
+  Sparkles,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useImageDetail, useGalleryNeighbors } from '@/hooks/useImageDetail';
+import { usePopularImages } from '@/hooks/useImages';
+import { useLikeToggle } from '@/hooks/useLikeToggle';
+import { useAuthStore } from '@/stores/authStore';
+import { useUIStore } from '@/stores/uiStore';
+import { cn } from '@/lib/utils';
+import type { ImageDetailResponse } from '@/types';
+
+const SURVIVAL_THRESHOLD = 50;
+
+function providerLabel(p: ImageDetailResponse['provider']): string {
+  switch (p) {
+    case 'NYANGMUNITY':
+      return '직접 업로드';
+    case 'TENOR':
+      return 'Tenor';
+    case 'THECATAPI':
+      return 'The Cat API';
+    default:
+      return p;
+  }
+}
+
+function formatUploadDate(dateStr: string | undefined): string {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '';
+  const now = Date.now();
+  const diff = now - d.getTime();
+  const day = 24 * 60 * 60 * 1000;
+  if (diff < day) return '오늘';
+  if (diff < 2 * day) return '어제';
+  if (diff < 30 * day) return `${Math.floor(diff / day)}일 전`;
+  return d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+function dDayFromExpires(expiresAt?: string | null): number | null {
+  if (!expiresAt) return null;
+  const exp = new Date(expiresAt).getTime();
+  if (Number.isNaN(exp)) return null;
+  return Math.max(0, Math.ceil((exp - Date.now()) / (24 * 60 * 60 * 1000)));
+}
+
+export function ImageDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isLogin = useAuthStore((s) => s.isLogin);
+  const openAuthPrompt = useUIStore((s) => s.openAuthPrompt);
+  const { data: image, isLoading, isError } = useImageDetail(id);
+  const { prev, next, position } = useGalleryNeighbors(id);
+  const toggleLike = useLikeToggle();
+
+  const { data: similarSource = [] } = usePopularImages(8);
+  const similar = useMemo(
+    () => similarSource.filter((s) => s.id !== id).slice(0, 5),
+    [similarSource, id],
+  );
+
+  useEffect(() => {
+    if (!image) return;
+    document.title = `${image.name ?? '이미지'} · NyangMunity`;
+    return () => {
+      document.title = 'NyangMunity';
+    };
+  }, [image]);
+
+  if (isLoading) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-background text-text-tertiary text-sm">
+        이미지 정보를 불러오는 중...
+      </div>
+    );
+  }
+
+  if (isError || !image) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center bg-background gap-4 px-6 text-center">
+        <p className="text-text-secondary text-sm">이미지를 찾을 수 없어요.</p>
+        <button
+          type="button"
+          className="nm-btn nm-btn--outline"
+          onClick={() => navigate('/posts')}
+        >
+          <ChevronsLeft size={16} /> 갤러리로 돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  const likeCount = image.likesCount;
+  const tags = image.tags ?? [];
+  const survived = likeCount >= SURVIVAL_THRESHOLD;
+  const pct = Math.min(100, (likeCount / SURVIVAL_THRESHOLD) * 100);
+  const dDay = dDayFromExpires(image.expiresAt);
+  const liked = image.likeState ?? false;
+  const uploader = image.uploader ?? null;
+  const uploaderInitial = uploader?.[0] ?? '?';
+
+  const handleLike = () => {
+    if (!isLogin) {
+      openAuthPrompt('좋아요는 로그인 후 이용할 수 있어요.');
+      return;
+    }
+    toggleLike.mutate(image.id);
+  };
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('링크를 복사했어요.');
+    } catch {
+      toast.error('복사에 실패했어요. 직접 주소를 복사해주세요.');
+    }
+  };
+
+  const goPrev = () => {
+    if (prev) navigate(`/images/${prev}`);
+  };
+  const goNext = () => {
+    if (next) navigate(`/images/${next}`);
+  };
+
+  return (
+    <div className="h-screen flex flex-col bg-background text-text-primary">
+      <header className="d2-topbar">
+        <div className="d2-topbar-left">
+          <button
+            type="button"
+            className="nm-btn nm-btn--ghost nm-btn--sm"
+            onClick={() => navigate(-1)}
+          >
+            <ChevronLeft size={16} /> 갤러리로
+          </button>
+          <span className="d2-divider" aria-hidden="true" />
+          <div className="d2-crumb">
+            <Link to="/posts" className="hover:text-text-primary transition-colors">
+              갤러리
+            </Link>
+            <ChevronRight />
+            <span>{providerLabel(image.provider)}</span>
+            <ChevronRight />
+            <span className="d2-crumb-current truncate max-w-[200px]">
+              {image.name ?? '이름 없음'}
+            </span>
+          </div>
+        </div>
+        <div className="d2-topbar-right">
+          {position && (
+            <span className="d2-pos">
+              {position.index} / {position.total}
+            </span>
+          )}
+          <button
+            type="button"
+            className="nm-btn nm-btn--ghost nm-btn--icon"
+            aria-label="이전 사진"
+            onClick={goPrev}
+            disabled={!prev}
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            type="button"
+            className="nm-btn nm-btn--ghost nm-btn--icon"
+            aria-label="다음 사진"
+            onClick={goNext}
+            disabled={!next}
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </header>
+
+      <div className="d2-body">
+        <section className="d2-image-col">
+          <div className="d2-image-frame">
+            <img src={image.url} alt={image.name ?? '고양이 사진'} />
+          </div>
+          <div className="d2-image-foot">
+            <div className="d2-image-foot-left">
+              <span className="nm-chip nm-chip--sm d2-breed">
+                {providerLabel(image.provider)}
+              </span>
+              <span className="d2-stat">
+                <Heart size={13} /> {likeCount.toLocaleString()}
+              </span>
+              <span className="d2-stat">
+                <Eye size={13} /> {image.viewsCount.toLocaleString()}
+              </span>
+            </div>
+            <div className="d2-image-foot-right">
+              <button
+                type="button"
+                className="nm-btn nm-btn--ghost nm-btn--sm"
+                onClick={handleShare}
+              >
+                <Share2 size={14} /> 공유
+              </button>
+              <a
+                className="nm-btn nm-btn--ghost nm-btn--sm"
+                href={image.url}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                <Maximize2 size={14} /> 원본
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <aside className="d2-info-col nm-scroll">
+          <section className="d2-section">
+            <div className="dd-author">
+              <div className="dd-author-avatar">{uploaderInitial}</div>
+              <div className="dd-author-meta">
+                <div className="dd-author-name">{uploader ?? '익명의 집사'}</div>
+                <div className="dd-author-handle">
+                  {formatUploadDate(image.uploadDate)} 업로드
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="d2-section d2-section--title">
+            <h1 className="d2-title">{image.name ?? '이름 없는 고양이'}</h1>
+            <div className="d2-subtitle">
+              <span className="d2-subtitle-time">
+                {providerLabel(image.provider)}
+              </span>
+            </div>
+            {image.description && (
+              <p className="d2-caption">{image.description}</p>
+            )}
+            {tags.length > 0 && (
+              <div className="dd-tags">
+                {tags.map((t) => (
+                  <span key={t.id} className="dd-tag">
+                    #{t.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="d2-section">
+            <div className="dd-survival">
+              <div className="dd-survival-head">
+                {survived ? (
+                  <span className="dd-survival-status dd-survival-status--saved">
+                    <Sparkles size={14} /> 영구 보관됨
+                  </span>
+                ) : (
+                  <span className="dd-survival-status">
+                    영구 보관까지{' '}
+                    <em>{SURVIVAL_THRESHOLD - likeCount}</em>개
+                  </span>
+                )}
+                <span className="dd-survival-num">
+                  {likeCount.toLocaleString()}
+                  {!survived && ` / ${SURVIVAL_THRESHOLD}`}
+                  {survived && <em> likes</em>}
+                </span>
+              </div>
+              <div className="dd-survival-track">
+                <div
+                  className={cn('dd-survival-fill', survived && 'is-survived')}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              {!survived && (
+                <div className="dd-survival-meta">
+                  {dDay !== null && <span className="dd-dday">D-{dDay}</span>}
+                  <span>좋아요 50개를 받으면 영원히 남습니다.</span>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="d2-section">
+            <div className="dd-actions">
+              <button
+                type="button"
+                className={cn('dd-action dd-action--like', liked && 'is-on')}
+                onClick={handleLike}
+              >
+                <Heart size={16} fill={liked ? 'currentColor' : 'none'} />
+                <span>{liked ? '좋아요 취소' : '좋아요'}</span>
+                <span className="dd-action-count">
+                  {likeCount.toLocaleString()}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="dd-action"
+                disabled
+                title="저장 기능은 곧 추가됩니다"
+              >
+                <Bookmark size={16} />
+                <span>저장</span>
+              </button>
+              <button
+                type="button"
+                className="dd-action"
+                onClick={handleShare}
+              >
+                <Share2 size={16} />
+                <span>공유</span>
+              </button>
+              <button
+                type="button"
+                className="dd-action dd-action--muted"
+                disabled
+                aria-label="신고 (준비 중)"
+              >
+                <Flag size={16} />
+              </button>
+            </div>
+          </section>
+
+          <div className="d2-divider-rule" />
+
+          <section className="d2-section">
+            <div className="dd-comments-placeholder">
+              <strong>
+                <MessageSquareText
+                  size={14}
+                  style={{ display: 'inline', verticalAlign: '-2px', marginRight: 6 }}
+                />
+                댓글
+              </strong>
+              댓글 기능은 v1.5에서 추가됩니다.
+            </div>
+          </section>
+
+          {similar.length > 0 && (
+            <>
+              <div className="d2-divider-rule" />
+              <section className="d2-section">
+                <div className="dd-similar">
+                  <div className="dd-similar-head">
+                    <h3 className="dd-similar-title">
+                      <Sparkles size={14} />
+                      비슷한 인기 사진
+                    </h3>
+                    <Link to="/posts" className="text-xs text-text-secondary hover:text-accent-bright">
+                      전체 보기
+                    </Link>
+                  </div>
+                  <div className="dd-similar-grid">
+                    {similar.map((s) => (
+                      <Link
+                        key={s.id}
+                        to={`/images/${s.id}`}
+                        className="dd-similar-tile"
+                      >
+                        <img src={s.thumbnailUrl ?? s.url} alt={s.name ?? ''} loading="lazy" />
+                        <div className="dd-similar-likes">
+                          <Heart size={10} />
+                          {s.likesCount.toLocaleString()}
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </>
+          )}
+        </aside>
+      </div>
+
+    </div>
+  );
+}

--- a/front-react/src/pages/ImageDetail.tsx
+++ b/front-react/src/pages/ImageDetail.tsx
@@ -144,7 +144,7 @@ export function ImageDetailPage() {
           <button
             type="button"
             className="nm-btn nm-btn--ghost nm-btn--sm"
-            onClick={() => navigate(-1)}
+            onClick={() => navigate('/posts')}
           >
             <ChevronLeft size={16} /> 갤러리로
           </button>

--- a/front-react/src/router/index.tsx
+++ b/front-react/src/router/index.tsx
@@ -1,8 +1,10 @@
 import { Routes, Route } from 'react-router-dom';
 import { AppShell } from '@/components/layout/AppShell';
+import { GlobalModals } from '@/components/common/GlobalModals';
 import { ProtectedRoute } from './ProtectedRoute';
 import { MainPage } from '@/pages/Main';
 import { GalleryPage } from '@/pages/Gallery';
+import { ImageDetailPage } from '@/pages/ImageDetail';
 import { LoginPage } from '@/pages/member/Login';
 import { JoinPage } from '@/pages/member/Join';
 import { MyPage } from '@/pages/member/MyPage';
@@ -10,22 +12,26 @@ import { SocialLoginCallbackPage } from '@/pages/member/SocialLoginCallback';
 
 export function AppRouter() {
   return (
-    <Routes>
-      <Route element={<AppShell />}>
-        <Route path="/" element={<MainPage />} />
-        <Route path="/posts" element={<GalleryPage />} />
-        <Route
-          path="/member/info"
-          element={
-            <ProtectedRoute>
-              <MyPage />
-            </ProtectedRoute>
-          }
-        />
-      </Route>
-      <Route path="/member/login" element={<LoginPage />} />
-      <Route path="/member/join" element={<JoinPage />} />
-      <Route path="/auth/:provider/callback" element={<SocialLoginCallbackPage />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/" element={<MainPage />} />
+          <Route path="/posts" element={<GalleryPage />} />
+          <Route
+            path="/member/info"
+            element={
+              <ProtectedRoute>
+                <MyPage />
+              </ProtectedRoute>
+            }
+          />
+        </Route>
+        <Route path="/images/:id" element={<ImageDetailPage />} />
+        <Route path="/member/login" element={<LoginPage />} />
+        <Route path="/member/join" element={<JoinPage />} />
+        <Route path="/auth/:provider/callback" element={<SocialLoginCallbackPage />} />
+      </Routes>
+      <GlobalModals />
+    </>
   );
 }

--- a/front-react/src/stores/uiStore.ts
+++ b/front-react/src/stores/uiStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface UIState {
+  authPromptOpen: boolean;
+  authPromptMessage: string | null;
+  uploadOpen: boolean;
+  openAuthPrompt: (message?: string) => void;
+  closeAuthPrompt: () => void;
+  openUpload: () => void;
+  closeUpload: () => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  authPromptOpen: false,
+  authPromptMessage: null,
+  uploadOpen: false,
+  openAuthPrompt: (message) =>
+    set({ authPromptOpen: true, authPromptMessage: message ?? null }),
+  closeAuthPrompt: () => set({ authPromptOpen: false, authPromptMessage: null }),
+  openUpload: () => set({ uploadOpen: true }),
+  closeUpload: () => set({ uploadOpen: false }),
+}));

--- a/front-react/src/styles/detail.css
+++ b/front-react/src/styles/detail.css
@@ -1,0 +1,416 @@
+/* 이미지 상세 페이지 (D2) — handoff detail-d2.css + detail-shared.css 에서 포팅.
+   레이아웃 골격과 시그니처 클래스만 가져오고, 댓글 같은 미지원 영역은 placeholder. */
+
+@layer components {
+  /* ───── D2 페이지 골격 ───── */
+  .d2-root {
+    position: absolute;
+    inset: 0;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-family: var(--font-kr);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .d2-topbar {
+    height: 56px;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 24px;
+    background: rgba(10, 10, 11, 0.85);
+    backdrop-filter: blur(12px);
+    z-index: 4;
+  }
+  .d2-topbar-left,
+  .d2-topbar-right { display: flex; align-items: center; gap: 14px; }
+  .d2-topbar-right { gap: 6px; }
+  .d2-divider { width: 1px; height: 18px; background: var(--border-default); }
+
+  .d2-crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: 500 13px var(--font-kr);
+    color: var(--text-tertiary);
+  }
+  .d2-crumb svg { width: 14px; height: 14px; }
+  .d2-crumb-current { color: var(--text-primary); }
+
+  .d2-pos {
+    font: 500 12px var(--font-en);
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+    padding-right: 4px;
+    letter-spacing: 0.02em;
+  }
+
+  .d2-body {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    overflow: hidden;
+  }
+  @media (max-width: 960px) {
+    .d2-body { grid-template-columns: 1fr; }
+  }
+
+  .d2-image-col {
+    background:
+      radial-gradient(600px 320px at 30% 40%, rgba(97, 97, 126, 0.08), transparent 70%),
+      var(--bg-base);
+    border-right: 1px solid var(--border-subtle);
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    position: relative;
+  }
+  @media (max-width: 960px) {
+    .d2-image-col { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+  }
+
+  .d2-image-frame {
+    flex: 1;
+    padding: 28px 32px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 0;
+  }
+  .d2-image-frame img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: var(--r-3);
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5), 0 0 0 1px var(--border-subtle);
+  }
+
+  .d2-image-foot {
+    padding: 12px 32px 22px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-shrink: 0;
+  }
+  .d2-image-foot-left,
+  .d2-image-foot-right { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .d2-breed {
+    background: var(--accent-subtle);
+    color: var(--accent-bright);
+    border-color: rgba(122, 122, 154, 0.4);
+  }
+  .d2-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font: 500 12.5px var(--font-en);
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+  .d2-stat svg { width: 13px; height: 13px; }
+
+  .d2-info-col {
+    overflow-y: auto;
+    background: var(--bg-base);
+    display: flex;
+    flex-direction: column;
+  }
+  .d2-section { padding: 18px 28px; }
+  .d2-section--title { padding-bottom: 22px; }
+
+  .d2-title {
+    font: 700 28px var(--font-kr);
+    letter-spacing: -0.03em;
+    color: var(--text-primary);
+    margin: 0 0 6px;
+  }
+  .d2-subtitle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 14px;
+    font: 400 12.5px var(--font-en);
+    color: var(--text-tertiary);
+  }
+  .d2-subtitle-time { font-family: var(--font-kr); }
+  .d2-caption {
+    font: 400 14px var(--font-kr);
+    line-height: 1.65;
+    color: var(--text-secondary);
+    margin: 0 0 16px;
+    white-space: pre-wrap;
+  }
+  .d2-divider-rule {
+    height: 1px;
+    background: var(--border-subtle);
+    margin: 8px 28px;
+  }
+
+  /* ───── 생존 게이지 ───── */
+  .dd-survival {
+    background: rgba(22, 22, 26, 0.6);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--r-3);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .dd-survival-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .dd-survival-status {
+    font: 500 13px var(--font-kr);
+    color: var(--text-secondary);
+  }
+  .dd-survival-status em {
+    font-style: normal;
+    font-weight: 700;
+    color: var(--accent-bright);
+  }
+  .dd-survival-status--saved {
+    color: var(--success);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+  }
+  .dd-survival-num {
+    font: 600 13px var(--font-en);
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+  .dd-survival-num em {
+    font-style: normal;
+    color: var(--text-tertiary);
+    font-weight: 400;
+    margin-left: 2px;
+  }
+  .dd-survival-track {
+    height: 6px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 9999px;
+    overflow: hidden;
+  }
+  .dd-survival-fill {
+    height: 100%;
+    background: linear-gradient(to right, var(--accent-base), var(--accent-bright));
+    border-radius: 9999px;
+    box-shadow: 0 0 12px var(--accent-glow);
+    transition: width 320ms var(--ease-out);
+  }
+  .dd-survival-fill.is-survived {
+    background: linear-gradient(to right, var(--success), #34d399);
+    box-shadow: 0 0 12px rgba(16, 185, 129, 0.4);
+  }
+  .dd-survival-meta {
+    font: 400 12px var(--font-kr);
+    color: var(--text-tertiary);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .dd-dday {
+    font: 600 11px var(--font-en);
+    padding: 2px 8px;
+    border-radius: 9999px;
+    background: rgba(245, 158, 11, 0.12);
+    color: #f59e0b;
+    letter-spacing: 0.02em;
+  }
+
+  /* ───── 액션 바 ───── */
+  .dd-actions {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .dd-action {
+    all: unset;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 38px;
+    padding: 0 14px;
+    border-radius: var(--r-2);
+    font: 500 13px var(--font-kr);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+    cursor: pointer;
+    transition: all 140ms var(--ease-out);
+  }
+  .dd-action svg { width: 16px; height: 16px; }
+  .dd-action:hover {
+    color: var(--text-primary);
+    border-color: var(--border-strong);
+    background: var(--bg-elevated);
+  }
+  .dd-action.is-on {
+    background: var(--accent-subtle);
+    color: var(--accent-bright);
+    border-color: rgba(122, 122, 154, 0.4);
+  }
+  .dd-action--like.is-on {
+    color: var(--like);
+    border-color: rgba(239, 68, 68, 0.4);
+    background: rgba(239, 68, 68, 0.1);
+  }
+  .dd-action--muted {
+    width: 38px;
+    padding: 0;
+    justify-content: center;
+    color: var(--text-tertiary);
+  }
+  .dd-action[disabled] { opacity: 0.5; cursor: not-allowed; }
+  .dd-action-count {
+    font-variant-numeric: tabular-nums;
+    font-family: var(--font-en);
+    font-weight: 600;
+    color: inherit;
+    padding-left: 6px;
+    border-left: 1px solid currentColor;
+    opacity: 0.9;
+    margin-left: 2px;
+  }
+
+  /* ───── 업로더(작성자) 블록 ───── */
+  .dd-author {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--r-3);
+  }
+  .dd-author-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, #5b5b78, #2e2e3e);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: 600 15px var(--font-kr);
+    color: #f4f4f5;
+    flex-shrink: 0;
+    border: 1px solid var(--border-default);
+  }
+  .dd-author-meta { flex: 1; min-width: 0; }
+  .dd-author-name {
+    font: 600 14px var(--font-kr);
+    color: var(--text-primary);
+  }
+  .dd-author-handle {
+    font: 400 12px var(--font-en);
+    color: var(--text-tertiary);
+  }
+
+  /* ───── 태그 ───── */
+  .dd-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .dd-tag {
+    font: 500 12px var(--font-kr);
+    color: var(--text-secondary);
+    padding: 5px 10px;
+    border-radius: 9999px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    cursor: pointer;
+    transition: all 140ms var(--ease-out);
+  }
+  .dd-tag:hover {
+    color: var(--accent-bright);
+    border-color: var(--border-default);
+  }
+
+  /* ───── 댓글 placeholder ───── */
+  .dd-comments-placeholder {
+    text-align: center;
+    padding: 28px 16px;
+    background: rgba(22, 22, 26, 0.5);
+    border: 1px dashed var(--border-subtle);
+    border-radius: var(--r-3);
+    font: 400 13px var(--font-kr);
+    color: var(--text-tertiary);
+    line-height: 1.6;
+  }
+  .dd-comments-placeholder strong {
+    display: block;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  /* ───── 비슷한 사진 스트립 ───── */
+  .dd-similar { display: flex; flex-direction: column; gap: 12px; }
+  .dd-similar-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+  .dd-similar-title {
+    font: 700 14px var(--font-kr);
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+  }
+  .dd-similar-title svg { color: var(--accent-bright); width: 14px; height: 14px; }
+  .dd-similar-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  @media (max-width: 480px) {
+    .dd-similar-grid { grid-template-columns: repeat(3, 1fr); }
+  }
+  .dd-similar-tile {
+    aspect-ratio: 1 / 1;
+    position: relative;
+    border-radius: var(--r-2);
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-elevated);
+    cursor: pointer;
+    transition: border-color 140ms var(--ease-out);
+  }
+  .dd-similar-tile:hover { border-color: var(--border-strong); }
+  .dd-similar-tile img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .dd-similar-likes {
+    position: absolute;
+    bottom: 6px;
+    left: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px 6px;
+    border-radius: 9999px;
+    background: rgba(10, 10, 11, 0.7);
+    backdrop-filter: blur(8px);
+    font: 600 10.5px var(--font-en);
+    color: #f4f4f5;
+  }
+  .dd-similar-likes svg {
+    width: 10px;
+    height: 10px;
+    color: var(--like);
+    fill: currentColor;
+  }
+}

--- a/front-react/src/styles/upload.css
+++ b/front-react/src/styles/upload.css
@@ -1,0 +1,381 @@
+/* 업로드 모달 — handoff upload-modal.css 에서 포팅.
+   디자인은 다중 이미지 staging 을 포함하지만 백엔드가 단건 등록만 지원해
+   단일 이미지 업로드만 지원한다. */
+
+@layer components {
+  .up-root {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 10, 11, 0.88);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-kr);
+    color: var(--text-primary);
+    z-index: 50;
+    padding: 24px;
+  }
+
+  .up-modal {
+    position: relative;
+    z-index: 5;
+    width: 100%;
+    max-width: 1100px;
+    height: 100%;
+    max-height: 820px;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    border-radius: var(--r-4);
+    overflow: hidden;
+    background: var(--bg-base);
+    border: 1px solid var(--border-default);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+  }
+  .up-modal--empty {
+    max-width: 760px;
+    max-height: 620px;
+  }
+
+  .up-header {
+    padding: 22px 28px 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .up-title {
+    font: 700 22px var(--font-kr);
+    letter-spacing: -0.025em;
+    margin: 0;
+  }
+  .up-subtitle {
+    font: 400 13px var(--font-kr);
+    color: var(--text-secondary);
+    margin: 6px 0 0;
+    line-height: 1.55;
+  }
+  .up-subtitle em {
+    font-style: normal;
+    font-weight: 600;
+    color: var(--accent-bright);
+  }
+  .up-close {
+    all: unset;
+    cursor: pointer;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--r-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-tertiary);
+    border: 1px solid transparent;
+    transition: all 140ms var(--ease-out);
+  }
+  .up-close:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    border-color: var(--border-default);
+  }
+
+  .up-body {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    min-height: 0;
+    overflow: hidden;
+  }
+  @media (max-width: 720px) {
+    .up-body { grid-template-columns: 1fr; }
+  }
+
+  .up-preview {
+    background: #000;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border-subtle);
+    min-width: 0;
+  }
+  .up-dropzone {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 0;
+  }
+  .up-preview-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+  .up-preview-shade {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0) 30%);
+    pointer-events: none;
+  }
+  .up-preview-replace {
+    all: unset;
+    cursor: pointer;
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 12px;
+    font: 500 12px var(--font-kr);
+    color: #f4f4f5;
+    background: rgba(10, 10, 11, 0.7);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--r-2);
+    transition: all 140ms var(--ease-out);
+  }
+  .up-preview-replace:hover { background: rgba(10, 10, 11, 0.9); }
+  .up-preview-replace svg { width: 14px; height: 14px; }
+  .up-preview-info {
+    position: absolute;
+    bottom: 14px;
+    left: 16px;
+    color: rgba(244, 244, 245, 0.85);
+  }
+  .up-preview-name { font: 500 12.5px var(--font-en); }
+  .up-preview-meta {
+    font: 400 11px var(--font-en);
+    color: rgba(244, 244, 245, 0.55);
+    margin-top: 2px;
+  }
+
+  .up-form {
+    padding: 22px 26px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: var(--bg-base);
+  }
+  .up-field { display: flex; flex-direction: column; gap: 8px; }
+  .up-label {
+    font: 500 13px var(--font-kr);
+    color: var(--text-primary);
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .up-label-opt {
+    font: 400 11.5px var(--font-kr);
+    color: var(--text-tertiary);
+  }
+
+  .up-tags-input {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    min-height: 38px;
+    padding: 6px 8px;
+    border-radius: var(--r-2);
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+  }
+  .up-tags-input:focus-within {
+    border-color: var(--accent-hover);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+  .up-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 4px 3px 10px;
+    border-radius: 9999px;
+    background: var(--accent-subtle);
+    color: var(--accent-bright);
+    font: 500 12px var(--font-kr);
+    border: 1px solid rgba(122, 122, 154, 0.4);
+  }
+  .up-tag button {
+    all: unset;
+    cursor: pointer;
+    width: 18px;
+    height: 18px;
+    border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-bright);
+    opacity: 0.7;
+  }
+  .up-tag button:hover {
+    background: rgba(255, 255, 255, 0.08);
+    opacity: 1;
+  }
+  .up-tag button svg { width: 10px; height: 10px; }
+  .up-tag-field {
+    all: unset;
+    flex: 1;
+    min-width: 120px;
+    font: 400 13px var(--font-kr);
+    color: var(--text-primary);
+    padding: 4px 6px;
+  }
+  .up-tag-field::placeholder { color: var(--text-tertiary); }
+
+  .up-suggest { display: flex; flex-wrap: wrap; gap: 4px; }
+  .up-suggest-chip {
+    all: unset;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 9999px;
+    font: 500 11.5px var(--font-kr);
+    color: var(--text-tertiary);
+    background: transparent;
+    border: 1px dashed var(--border-default);
+    transition: all 140ms var(--ease-out);
+  }
+  .up-suggest-chip:hover {
+    color: var(--text-primary);
+    border-color: var(--border-strong);
+    border-style: solid;
+  }
+
+  .up-textarea {
+    padding: 10px 12px;
+    border-radius: var(--r-2);
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+    font: 400 14px var(--font-kr);
+    color: var(--text-primary);
+    resize: vertical;
+    outline: none;
+    width: 100%;
+    line-height: 1.55;
+  }
+  .up-textarea:focus {
+    border-color: var(--accent-hover);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+  .up-textarea::placeholder { color: var(--text-tertiary); }
+  .up-counter {
+    align-self: flex-end;
+    font: 500 11px var(--font-en);
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .up-notice {
+    display: flex;
+    gap: 10px;
+    padding: 12px 14px;
+    background: rgba(245, 158, 11, 0.06);
+    border: 1px solid rgba(245, 158, 11, 0.15);
+    border-radius: var(--r-2);
+  }
+  .up-notice-icon {
+    width: 18px;
+    height: 18px;
+    color: #f59e0b;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+  .up-notice-text {
+    font: 400 12px var(--font-kr);
+    color: var(--text-secondary);
+    line-height: 1.55;
+  }
+  .up-notice-text strong {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .up-footer {
+    padding: 14px 28px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    background: var(--bg-base);
+    border-top: 1px solid var(--border-subtle);
+  }
+  .up-footer-right { display: flex; gap: 8px; }
+  .up-clock {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font: 400 12.5px var(--font-kr);
+    color: var(--text-tertiary);
+  }
+  .up-clock-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: var(--accent-bright);
+    box-shadow: 0 0 10px var(--accent-glow);
+  }
+  .up-clock-text em {
+    font-style: normal;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .up-empty {
+    grid-column: 1 / -1;
+    padding: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background:
+      radial-gradient(400px 200px at 50% 40%, var(--accent-faint), transparent 70%),
+      var(--bg-base);
+  }
+  .up-empty-zone {
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+    border-radius: var(--r-3);
+    border: 2px dashed var(--border-default);
+    background: rgba(22, 22, 26, 0.4);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 140ms var(--ease-out), background 140ms var(--ease-out);
+  }
+  .up-empty-zone:hover,
+  .up-empty-zone.is-dragging {
+    border-color: var(--accent-bright);
+    background: var(--accent-faint);
+  }
+  .up-empty-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 9999px;
+    background: var(--accent-subtle);
+    border: 1px solid rgba(122, 122, 154, 0.4);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-bright);
+    margin-bottom: 22px;
+  }
+  .up-empty-icon svg { width: 28px; height: 28px; }
+  .up-empty-title {
+    font: 700 22px var(--font-kr);
+    letter-spacing: -0.02em;
+    color: var(--text-primary);
+    margin: 0 0 8px;
+  }
+  .up-empty-sub {
+    font: 400 13px var(--font-kr);
+    color: var(--text-tertiary);
+    margin: 0 0 24px;
+  }
+}

--- a/front-react/src/types/index.ts
+++ b/front-react/src/types/index.ts
@@ -56,3 +56,36 @@ export interface TopLikeResponse {
 }
 
 export type SortKey = 'latest' | 'likes' | 'views';
+
+export interface TagSummary {
+  id: string;
+  name: string;
+  usageCount?: number;
+}
+
+export interface ImageDetailResponse {
+  id: string;
+  name: string | null;
+  url: string;
+  thumbnailUrl: string | null;
+  description: string | null;
+  provider: Provider;
+  uploadDate: string;
+  likesCount: number;
+  viewsCount: number;
+  uploader: string | null;
+  tags: TagSummary[];
+  likeState: boolean;
+  expiresAt?: string | null;
+}
+
+export interface UploadUrlResponse {
+  id: string;
+  uploadUrl: string;
+}
+
+export interface ImageUploadCompleteRequest {
+  imageId: string;
+  description?: string;
+  tags?: string[];
+}

--- a/src/main/java/cat/community/nyangmunity/postImage/image/service/ImageLikeCommandService.java
+++ b/src/main/java/cat/community/nyangmunity/postImage/image/service/ImageLikeCommandService.java
@@ -25,11 +25,13 @@ public class ImageLikeCommandService {
 
 	@Transactional
 	public ImageLikeResponse likeImageProcess(String imageId, Member member) {
-		Optional<ImageLike> imageLike = imageQueryService.findImageLike(imageId, member.getId());
+		Image image = imageRepository.findById(imageId).orElseThrow(BadRequestException::new);
+		Optional<ImageLike> existing = imageQueryService.findImageLike(imageId, member.getId());
 
-		// 만약, 이미지 좋아요를 누른 상태라면 취소 작업
-		if (imageLike.isPresent()) {
-			unlikeImage(imageLike.get());
+		// 이미 좋아요를 누른 상태라면 취소 작업
+		if (existing.isPresent()) {
+			unlikeImage(existing.get());
+			image.decrementLikes();
 			return ImageLikeResponse.builder()
 				.imageId(imageId)
 				.state(false)
@@ -37,12 +39,12 @@ public class ImageLikeCommandService {
 		}
 
 		// 좋아요를 누른 상태가 아니라면 좋아요 등록
-		Image image = imageRepository.findById(imageId).orElseThrow(BadRequestException::new);
 		likeImage(ImageLike.builder()
 			.member(member)
 			.image(image)
 			.build()
 		);
+		image.incrementLikes();
 
 		return ImageLikeResponse.builder()
 			.imageId(imageId)


### PR DESCRIPTION
## 요약

M3 마이그레이션 (PRD §3.3 F2 미완 항목) 마무리. 이미지 상세 페이지·업로드 모달·비로그인 유도 모달을 추가하고, 디자인·동작 회귀 4건을 같이 잡았습니다.

## 변경 내용

### 신규 기능

- **이미지 상세 페이지** — 모달이 아닌 독립 URL `/images/:id`. 좌·우 이전·다음 탐색, 좋아요·북마크·공유·다운로드 액션. (F2.7)
- **업로드 모달** — Presigned URL 흐름으로 직접 업로드. 갤러리 진입점 + 사이드바 "사진 올리기" 버튼에서 호출.
- **비로그인 좋아요 유도 모달** — 비로그인 상태에서 좋아요·업로드 클릭 시 로그인 유도. (F2.10)

### 픽스

- 상세 페이지 "갤러리로" 가 단순 뒤로가기로 동작해, 다음 사진을 본 뒤 누르면 이전 사진이 다시 열리던 문제 → `/posts` 로 직접 이동
- 메인 큐레이션 bento 타일이 클릭돼도 상세 페이지로 이동하지 않던 문제 → 타일 전체를 링크로
- **이미지 좋아요 토글 시 카운트가 갱신되지 않아 항상 0으로 표시되던 문제** — 토글 서비스가 `image_like` 테이블만 건드리고 `image.likes_count` 컬럼을 안 올렸음. 토글 시 엔티티의 카운트 메서드를 호출하도록 수정. 기존 데이터는 보정 SQL 적용 완료.
- 사이드바 접었을 때 로고·텍스트만 숨기고 메뉴·업로드·로그인 아이콘 버튼은 유지하도록 정리 (244px ↔ 60px). 펼치기 버튼은 상단에 단독 노출.

## 테스트 플랜

- [x] 갤러리에서 카드 클릭 → 상세 페이지 진입, URL 공유 가능
- [x] 상세 페이지 좌·우 화살표·키보드 ←→ 로 다음·이전 사진 이동
- [x] 상세에서 "갤러리로" 누르면 항상 `/posts` 로 (이전 사진 X)
- [x] 메인 bento 타일 클릭 → 상세 페이지 진입
- [x] 좋아요 토글 후 새로고침해도 카운트 유지 (+1 / -1 사라지지 않음)
- [x] 비로그인 상태에서 좋아요·업로드 클릭 시 로그인 유도 모달 노출
- [x] 사이드바 접기 → 60px 폭. 펼치기·업로드·갤러리·커뮤니티·내 컬렉션·저장·로그인(또는 아바타) 아이콘만 노출, 텍스트·로고 사라짐
- [x] 사이드바 펼치기 → 244px 폭. 로고·라벨·뱃지 모두 복귀

## 후속 작업 (별도 PR)

- `refactor/back/auth` — JWT 만료 1h/30d 변경 + 인증 로직 전반 점검 + PRD §8.3 D4·dev·prod yml 정합성
- `feat/image/upload-with-name` — 업로드 시 제목 입력 (백엔드 DTO 보강 + 프론트 입력 필드)
- 업로드 후 이미지가 안 보이는 케이스 — 별도 확인 후 결정