### PR TITLE
Refactor: [back] auth

### DIFF
--- a/front-react/src/api/auth.ts
+++ b/front-react/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { axiosClient } from '@/lib/axios';
-import type { MemberAuthenticationResponse } from '@/types';
+import type { MemberResponse } from '@/types';
 
 export type SocialProvider = 'kakao' | 'google';
 
@@ -9,6 +9,6 @@ export const authApi = {
 
   exchangeCode: (provider: SocialProvider, code: string) =>
     axiosClient
-      .get<MemberAuthenticationResponse>(`/auth/${provider}/callback`, { params: { code } })
+      .get<MemberResponse>(`/auth/${provider}/callback`, { params: { code } })
       .then((r) => r.data),
 };

--- a/front-react/src/lib/axios.ts
+++ b/front-react/src/lib/axios.ts
@@ -67,9 +67,9 @@ axiosClient.interceptors.response.use(
 
     if (!originalRequest) return Promise.reject(error);
 
-    // TOKEN_EXPIRED 만 재발급 신호. TOKEN_INVALID·그 외 401 (블랙리스트·서명 위조·세션 만료) 은
-    // 재발급해도 같은 코드로 또 거부될 가능성이 높아 즉시 로컬 인증을 정리한다.
-    if (error.response.data?.code !== 'TOKEN_EXPIRED') {
+    // 명시적으로 무효 처리된 토큰만 즉시 정리한다. 그 외 401 (만료, 토큰 미첨부, 일반 인증 실패)
+    // 은 일단 재발급을 시도하고 그것마저 실패하면 catch 분기에서 정리한다.
+    if (error.response.data?.code === 'TOKEN_INVALID') {
       clearLocalAuth();
       return Promise.reject(error);
     }

--- a/front-react/src/lib/axios.ts
+++ b/front-react/src/lib/axios.ts
@@ -7,7 +7,6 @@ import type { MemberAuthenticationResponse } from '@/types';
 type RetryableRequest = InternalAxiosRequestConfig & { _retry?: boolean };
 
 const ACCESS_COOKIE = 'accessToken';
-const REFRESH_COOKIE = 'refreshToken';
 
 export const axiosClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -35,6 +34,8 @@ function onRefreshed(token?: string) {
   refreshSubscribers = [];
 }
 
+// Refresh 쿠키는 HttpOnly 라 JS 가 직접 첨부할 수 없지만 withCredentials:true 로 자동 전송된다.
+// 백엔드가 응답 Set-Cookie 로 access·refresh 를 함께 갱신해 내려주므로 프론트는 별도 저장이 필요 없다.
 async function requestReissue(): Promise<MemberAuthenticationResponse> {
   const response = await axios.post<MemberAuthenticationResponse>(
     `${import.meta.env.VITE_API_BASE_URL}/tokens`,
@@ -44,14 +45,10 @@ async function requestReissue(): Promise<MemberAuthenticationResponse> {
   return response.data;
 }
 
-function saveTokens(tokens: { accessToken: string; refreshToken: string }) {
-  Cookies.set(ACCESS_COOKIE, tokens.accessToken);
-  Cookies.set(REFRESH_COOKIE, tokens.refreshToken);
-}
-
-function clearTokensAndLogout() {
+// Access 만 JS-readable 이라 클라이언트가 직접 지울 수 있다. Refresh 는 HttpOnly 이므로
+// 백엔드 logout API 의 응답 Set-Cookie 가 maxAge=0 으로 제거하는 것을 신뢰한다.
+function clearLocalAuth() {
   Cookies.remove(ACCESS_COOKIE);
-  Cookies.remove(REFRESH_COOKIE);
   useAuthStore.getState().clearMember();
 }
 
@@ -72,7 +69,7 @@ axiosClient.interceptors.response.use(
 
     if (originalRequest._retry) {
       toast.warning('재로그인 해주세요!');
-      clearTokensAndLogout();
+      clearLocalAuth();
       return Promise.reject(error);
     }
 
@@ -82,7 +79,6 @@ axiosClient.interceptors.response.use(
 
       try {
         const reissued = await requestReissue();
-        saveTokens(reissued.memberTokens);
         useAuthStore.getState().setMember(reissued.memberInfoResponse);
 
         const newToken = reissued.memberTokens.accessToken;
@@ -93,7 +89,7 @@ axiosClient.interceptors.response.use(
       } catch (reissueError) {
         toast.warning('세션이 만료되었습니다. 다시 로그인해주세요.');
         onRefreshed();
-        clearTokensAndLogout();
+        clearLocalAuth();
         return Promise.reject(reissueError);
       } finally {
         isRefreshing = false;
@@ -114,10 +110,7 @@ axiosClient.interceptors.response.use(
 );
 
 export const tokenCookies = {
-  save: saveTokens,
-  clear: () => {
-    Cookies.remove(ACCESS_COOKIE);
-    Cookies.remove(REFRESH_COOKIE);
-  },
-  hasAny: () => Boolean(Cookies.get(ACCESS_COOKIE) || Cookies.get(REFRESH_COOKIE)),
+  clear: clearLocalAuth,
+  // Refresh 쿠키는 HttpOnly 라 JS 가 못 읽으므로 persisted 인증 상태로 추정한다.
+  hasAny: () => useAuthStore.getState().isLogin || Boolean(Cookies.get(ACCESS_COOKIE)),
 };

--- a/front-react/src/lib/axios.ts
+++ b/front-react/src/lib/axios.ts
@@ -54,7 +54,7 @@ function clearLocalAuth() {
 
 axiosClient.interceptors.response.use(
   (response) => response,
-  async (error: AxiosError<{ message?: string }>) => {
+  async (error: AxiosError<{ code?: string; message?: string }>) => {
     const originalRequest = error.config as RetryableRequest | undefined;
 
     if (error.response?.status !== 401) {
@@ -66,6 +66,13 @@ axiosClient.interceptors.response.use(
     }
 
     if (!originalRequest) return Promise.reject(error);
+
+    // TOKEN_EXPIRED 만 재발급 신호. TOKEN_INVALID·그 외 401 (블랙리스트·서명 위조·세션 만료) 은
+    // 재발급해도 같은 코드로 또 거부될 가능성이 높아 즉시 로컬 인증을 정리한다.
+    if (error.response.data?.code !== 'TOKEN_EXPIRED') {
+      clearLocalAuth();
+      return Promise.reject(error);
+    }
 
     if (originalRequest._retry) {
       toast.warning('재로그인 해주세요!');

--- a/front-react/src/pages/member/SocialLoginCallback.tsx
+++ b/front-react/src/pages/member/SocialLoginCallback.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { authApi, type SocialProvider } from '@/api/auth';
-import { tokenCookies } from '@/lib/axios';
 import { useAuthStore } from '@/stores/authStore';
 
 export function SocialLoginCallbackPage() {
@@ -26,7 +25,6 @@ export function SocialLoginCallbackPage() {
     authApi
       .exchangeCode(provider as SocialProvider, code)
       .then((auth) => {
-        tokenCookies.save(auth.memberTokens);
         setMember(auth.memberInfoResponse);
         toast.success(`환영합니다, ${auth.memberInfoResponse.nickname}님`);
         navigate('/', { replace: true });

--- a/front-react/src/pages/member/SocialLoginCallback.tsx
+++ b/front-react/src/pages/member/SocialLoginCallback.tsx
@@ -24,9 +24,9 @@ export function SocialLoginCallbackPage() {
 
     authApi
       .exchangeCode(provider as SocialProvider, code)
-      .then((auth) => {
-        setMember(auth.memberInfoResponse);
-        toast.success(`환영합니다, ${auth.memberInfoResponse.nickname}님`);
+      .then((member) => {
+        setMember(member);
+        toast.success(`환영합니다, ${member.nickname}님`);
         navigate('/', { replace: true });
       })
       .catch(() => {

--- a/src/main/java/cat/community/nyangmunity/global/config/AppConfig.java
+++ b/src/main/java/cat/community/nyangmunity/global/config/AppConfig.java
@@ -12,17 +12,27 @@ import lombok.Getter;
 @Configuration
 public class AppConfig {
 
+	private static final int MIN_JWT_KEY_BYTES = 32; // HMAC-SHA256 최소 키 길이
+
 	@Value("${nyangmunity.jwt-key}")
 	private String encodedJwtKey;
 
 	@Value("${nyangmunity.domain}")
 	private String domain;
 
+	@Value("${nyangmunity.cookie-secure}")
+	private boolean cookieSecure;
+
 	private byte[] jwtKey;
 
 	@PostConstruct
 	public void init() {
 		this.jwtKey = Base64.getDecoder().decode(encodedJwtKey);
+		if (this.jwtKey.length < MIN_JWT_KEY_BYTES) {
+			throw new IllegalStateException(
+				"nyangmunity.jwt-key 가 너무 짧습니다. HMAC-SHA256 은 최소 " + MIN_JWT_KEY_BYTES + " bytes 필요."
+			);
+		}
 	}
 }
 

--- a/src/main/java/cat/community/nyangmunity/global/config/SecurityConfig.java
+++ b/src/main/java/cat/community/nyangmunity/global/config/SecurityConfig.java
@@ -71,8 +71,8 @@ public class SecurityConfig {
 						HttpMethod.GET,
 						"/auth/kakao/url",
 						"/auth/google/url",
-						"/auth/kakaoLogin",
-						"/auth/googleLogin"
+						"/auth/kakao/callback",
+						"/auth/google/callback"
 					).permitAll()
 
 					.anyRequest().authenticated()

--- a/src/main/java/cat/community/nyangmunity/global/controller/ExceptionController.java
+++ b/src/main/java/cat/community/nyangmunity/global/controller/ExceptionController.java
@@ -19,9 +19,10 @@ public class ExceptionController {
 	@ExceptionHandler(NyangmunityException.class)
 	public ResponseEntity<ErrorResponse> globalResponseException(NyangmunityException e) {
 		int statusCode = e.getStatusCode();
+		String code = e.getErrorCode() != null ? e.getErrorCode() : String.valueOf(statusCode);
 
 		ErrorResponse body = ErrorResponse.builder()
-			.code(String.valueOf(statusCode))
+			.code(code)
 			.message(e.getMessage())
 			.validation(e.getValidation())
 			.build();

--- a/src/main/java/cat/community/nyangmunity/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/cat/community/nyangmunity/global/exception/CustomAccessDeniedHandler.java
@@ -1,16 +1,27 @@
 package cat.community.nyangmunity.global.exception;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cat.community.nyangmunity.global.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private static final String ERROR_CODE = "ACCESS_DENIED";
+	private static final String MESSAGE = "권한이 없습니다.";
+
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
@@ -18,6 +29,14 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		response.setContentType("application/json;charset=UTF-8");
-		response.getWriter().write("{\"message\": \"권한이 없습니다.\"}");
+		response.setCharacterEncoding("UTF-8");
+
+		ErrorResponse body = ErrorResponse.builder()
+			.code(ERROR_CODE)
+			.message(MESSAGE)
+			.validation(Map.of())
+			.build();
+
+		response.getWriter().write(objectMapper.writeValueAsString(body));
 	}
 }

--- a/src/main/java/cat/community/nyangmunity/global/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/cat/community/nyangmunity/global/exception/CustomAuthenticationEntryPoint.java
@@ -1,16 +1,27 @@
 package cat.community.nyangmunity.global.exception;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cat.community.nyangmunity.global.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final String ERROR_CODE = "UNAUTHENTICATED";
+	private static final String MESSAGE = "인증이 필요합니다.";
+
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -18,6 +29,14 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
-		response.getWriter().write("{\"message\": \"인증이 필요합니다.\"}");
+		response.setCharacterEncoding("UTF-8");
+
+		ErrorResponse body = ErrorResponse.builder()
+			.code(ERROR_CODE)
+			.message(MESSAGE)
+			.validation(Map.of())
+			.build();
+
+		response.getWriter().write(objectMapper.writeValueAsString(body));
 	}
 }

--- a/src/main/java/cat/community/nyangmunity/global/exception/NyangmunityException.java
+++ b/src/main/java/cat/community/nyangmunity/global/exception/NyangmunityException.java
@@ -19,6 +19,15 @@ public abstract class NyangmunityException extends RuntimeException {
 
 	public abstract int getStatusCode();
 
+	/**
+	 * 응답 body 의 의미적 에러 코드. 클라이언트가 HTTP status 만으로는 분기하기 어려운 경우
+	 * (예: 401 안에서 TOKEN_EXPIRED vs TOKEN_INVALID) 에 사용한다. null 이면 ExceptionController 가
+	 * statusCode 문자열로 폴백한다.
+	 */
+	public String getErrorCode() {
+		return null;
+	}
+
 	public void addValidation(String filedName, String message) {
 		validation.put(filedName, message);
 	}

--- a/src/main/java/cat/community/nyangmunity/global/exception/member/AccessTokenExpiredException.java
+++ b/src/main/java/cat/community/nyangmunity/global/exception/member/AccessTokenExpiredException.java
@@ -1,0 +1,26 @@
+package cat.community.nyangmunity.global.exception.member;
+
+import cat.community.nyangmunity.global.exception.NyangmunityException;
+
+/**
+ * Access 토큰이 만료된 경우. 프론트는 이 코드를 받으면 /tokens 로 재발급을 시도한다.
+ */
+public class AccessTokenExpiredException extends NyangmunityException {
+
+	private static final String MESSAGE = "토큰이 만료되었습니다.";
+	private static final String ERROR_CODE = "TOKEN_EXPIRED";
+
+	public AccessTokenExpiredException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 401;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return ERROR_CODE;
+	}
+}

--- a/src/main/java/cat/community/nyangmunity/global/exception/member/AccessTokenInvalidException.java
+++ b/src/main/java/cat/community/nyangmunity/global/exception/member/AccessTokenInvalidException.java
@@ -1,0 +1,27 @@
+package cat.community.nyangmunity.global.exception.member;
+
+import cat.community.nyangmunity.global.exception.NyangmunityException;
+
+/**
+ * Access 토큰 서명·구조가 잘못됐거나 블랙리스트에 등록된 경우. 프론트는 이 코드를 받으면
+ * 재발급을 시도하지 않고 즉시 로컬 인증 상태를 정리한다.
+ */
+public class AccessTokenInvalidException extends NyangmunityException {
+
+	private static final String MESSAGE = "올바르지 않은 토큰입니다.";
+	private static final String ERROR_CODE = "TOKEN_INVALID";
+
+	public AccessTokenInvalidException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 401;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return ERROR_CODE;
+	}
+}

--- a/src/main/java/cat/community/nyangmunity/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/cat/community/nyangmunity/global/filter/JwtAuthenticationFilter.java
@@ -2,59 +2,73 @@ package cat.community.nyangmunity.global.filter;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import cat.community.nyangmunity.global.data.JwtValidateStatus;
+import cat.community.nyangmunity.global.exception.NyangmunityException;
 import cat.community.nyangmunity.global.exception.global.InternalServerErrorException;
-import cat.community.nyangmunity.global.exception.global.UnauthorizedException;
+import cat.community.nyangmunity.global.exception.member.AccessTokenExpiredException;
+import cat.community.nyangmunity.global.exception.member.AccessTokenInvalidException;
 import cat.community.nyangmunity.global.provider.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final HandlerExceptionResolver resolver;
+
+	public JwtAuthenticationFilter(
+		JwtTokenProvider jwtTokenProvider,
+		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+	) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.resolver = resolver;
+	}
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 		String accessToken = getTokenFromRequest(request);
 
-		if (!StringUtils.hasText(accessToken)) { // AccessToken 이 존재하지 않을 때
+		if (!StringUtils.hasText(accessToken)) {
 			filterChain.doFilter(request, response);
 			return;
 		}
 
-		if (StringUtils.hasText(accessToken)) {
-			JwtValidateStatus validateStatus = jwtTokenProvider.validateToken(accessToken);
-
-			switch (validateStatus) {
-				case DENIED -> {
-					SecurityContextHolder.clearContext();
-					throw new UnauthorizedException("올바르지 않은 토큰입니다.");
-				}
-				case EXPIRED -> {
-					SecurityContextHolder.clearContext();
-					throw new UnauthorizedException("토큰이 만료되었습니다.");
-				}
-				case ACCEPTED -> {
-					Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-					SecurityContextHolder.getContext().setAuthentication(authentication);
-				}
-				default -> throw new InternalServerErrorException();
-			}
+		try {
+			authenticate(accessToken);
+		} catch (NyangmunityException e) {
+			// Filter 단계에서 던진 예외는 @RestControllerAdvice 로 도달하지 않으므로 직접 위임한다.
+			// 위임 후에는 chain 진행을 중단해야 응답이 중복 작성되지 않는다.
+			SecurityContextHolder.clearContext();
+			resolver.resolveException(request, response, null, e);
+			return;
 		}
 
 		filterChain.doFilter(request, response);
+	}
+
+	private void authenticate(String accessToken) {
+		JwtValidateStatus status = jwtTokenProvider.validateToken(accessToken);
+		switch (status) {
+			case ACCEPTED -> {
+				Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+			case EXPIRED -> throw new AccessTokenExpiredException();
+			case DENIED -> throw new AccessTokenInvalidException();
+			default -> throw new InternalServerErrorException();
+		}
 	}
 
 	private static String getTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/cat/community/nyangmunity/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/cat/community/nyangmunity/global/filter/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import cat.community.nyangmunity.global.exception.global.InternalServerErrorExce
 import cat.community.nyangmunity.global.exception.member.AccessTokenExpiredException;
 import cat.community.nyangmunity.global.exception.member.AccessTokenInvalidException;
 import cat.community.nyangmunity.global.provider.JwtTokenProvider;
+import cat.community.nyangmunity.member.redisRepository.AccessTokenBlacklistRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,13 +26,16 @@ import jakarta.servlet.http.HttpServletResponse;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 	private final HandlerExceptionResolver resolver;
 
 	public JwtAuthenticationFilter(
 		JwtTokenProvider jwtTokenProvider,
+		AccessTokenBlacklistRepository accessTokenBlacklistRepository,
 		@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
 	) {
 		this.jwtTokenProvider = jwtTokenProvider;
+		this.accessTokenBlacklistRepository = accessTokenBlacklistRepository;
 		this.resolver = resolver;
 	}
 
@@ -62,6 +66,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		JwtValidateStatus status = jwtTokenProvider.validateToken(accessToken);
 		switch (status) {
 			case ACCEPTED -> {
+				if (accessTokenBlacklistRepository.isBlacklisted(jwtTokenProvider.getJti(accessToken))) {
+					throw new AccessTokenInvalidException();
+				}
 				Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}

--- a/src/main/java/cat/community/nyangmunity/global/provider/CookieProvider.java
+++ b/src/main/java/cat/community/nyangmunity/global/provider/CookieProvider.java
@@ -2,6 +2,7 @@ package cat.community.nyangmunity.global.provider;
 
 import java.time.Duration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -10,38 +11,71 @@ import cat.community.nyangmunity.global.config.AppConfig;
 @Component
 public class CookieProvider {
 
-	String domain;
+	public static final String ACCESS_TOKEN_COOKIE = "accessToken";
+	public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
-	public CookieProvider(AppConfig appConfig) {
+	private static final String SAME_SITE = "Lax";
+	private static final String COOKIE_PATH = "/";
+
+	private final String domain;
+	private final boolean secure;
+	private final long accessTokenExpirationMs;
+	private final long refreshTokenExpirationMs;
+
+	public CookieProvider(
+		AppConfig appConfig,
+		@Value("${jwt.access-token-expiration}") long accessTokenExpirationMs,
+		@Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationMs
+	) {
 		this.domain = appConfig.getDomain();
+		this.secure = appConfig.isCookieSecure();
+		this.accessTokenExpirationMs = accessTokenExpirationMs;
+		this.refreshTokenExpirationMs = refreshTokenExpirationMs;
 	}
 
+	/**
+	 * Access 토큰 쿠키. 프론트 axios 인터셉터가 JS 로 읽어 Authorization Bearer 헤더에 첨부해야 하므로
+	 * HttpOnly=false 로 둔다. (XSS 노출 위험 vs 프론트 구조 변경 비용을 저울질해서 후자로 결정 — PRD §8.3 D4)
+	 */
 	public ResponseCookie createAccessTokenCookie(String accessToken) {
-
-		return ResponseCookie.from("accessToken", accessToken)
-			.domain(domain)
-			.path("/")
+		return baseCookie(ACCESS_TOKEN_COOKIE, accessToken, accessTokenExpirationMs)
 			.httpOnly(false)
-			.secure(false)
-			.maxAge(Duration.ofMinutes(30))
 			.build();
 	}
 
+	/**
+	 * Refresh 토큰 쿠키. /tokens 재발급 요청 시에만 자동 첨부되도록 HttpOnly + SameSite=Lax.
+	 */
 	public ResponseCookie createRefreshTokenCookie(String refreshToken) {
-
-		return ResponseCookie.from("refreshToken", refreshToken)
-			.domain(domain)
-			.path("/")
-			.httpOnly(false)
-			.secure(false)
-			.maxAge(Duration.ofDays(1))
+		return baseCookie(REFRESH_TOKEN_COOKIE, refreshToken, refreshTokenExpirationMs)
+			.httpOnly(true)
 			.build();
 	}
 
-	public ResponseCookie removeToken(String cookieName) {
-		return ResponseCookie.from(cookieName, null)
+	public ResponseCookie removeAccessTokenCookie() {
+		return removeCookie(ACCESS_TOKEN_COOKIE, false);
+	}
+
+	public ResponseCookie removeRefreshTokenCookie() {
+		return removeCookie(REFRESH_TOKEN_COOKIE, true);
+	}
+
+	private ResponseCookie.ResponseCookieBuilder baseCookie(String name, String value, long maxAgeMs) {
+		return ResponseCookie.from(name, value)
 			.domain(domain)
-			.path("/")
+			.path(COOKIE_PATH)
+			.secure(secure)
+			.sameSite(SAME_SITE)
+			.maxAge(Duration.ofMillis(maxAgeMs));
+	}
+
+	private ResponseCookie removeCookie(String name, boolean httpOnly) {
+		return ResponseCookie.from(name, "")
+			.domain(domain)
+			.path(COOKIE_PATH)
+			.secure(secure)
+			.sameSite(SAME_SITE)
+			.httpOnly(httpOnly)
 			.maxAge(0)
 			.build();
 	}

--- a/src/main/java/cat/community/nyangmunity/global/provider/JwtTokenProvider.java
+++ b/src/main/java/cat/community/nyangmunity/global/provider/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package cat.community.nyangmunity.global.provider;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.UUID;
 
 import javax.crypto.SecretKey;
 
@@ -36,25 +37,19 @@ public class JwtTokenProvider {
 	}
 
 	/**
-	 * 접근 토큰 생성을 위한 메서드
-	 * @param memberId subject 등록을 위한 회원 아이디
-	 * @return 생성된 접근 토큰
+	 * Access 토큰 생성. jti 를 부여해 로그아웃 시 블랙리스트 키로 사용한다.
 	 */
 	public String createAccessToken(Long memberId) {
 		Date now = new Date();
 		return Jwts.builder()
+			.id(UUID.randomUUID().toString())
 			.subject(memberId.toString())
 			.signWith(secretKey)
-			.expiration(new Date(now.getTime() + accessTokenExpiration)) // 30분
+			.expiration(new Date(now.getTime() + accessTokenExpiration))
 			.issuedAt(now)
 			.compact();
 	}
 
-	/**
-	 * 갱신 토큰 생성을 위한 메서드
-	 * @param memberId subject 등록을 위한 회원 아이디
-	 * @return 생성된 갱신 토큰
-	 */
 	public String createRefreshToken(Long memberId) {
 		Date now = new Date();
 		return Jwts.builder()
@@ -65,11 +60,6 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
-	/**
-	 * 토큰 내 정보를 확인하기 위한 메서드
-	 * @param token 접근 토큰 혹은 갱신 토큰
-	 * @return 토큰 내 정보
-	 */
 	public Claims getClaims(String token) {
 		return Jwts.parser()
 			.verifyWith(secretKey)
@@ -78,14 +68,6 @@ public class JwtTokenProvider {
 			.getPayload();
 	}
 
-	/**
-	 * 토큰 검증을 위한 메서드
-	 * @param token 접근 토큰 혹은 갱신 토큰
-	 * @return JwtValidateStatus
-	 *  ACCEPTED 검증 완료
-	 *  EXPIRED 만료
-	 *  DENIED 검증 실패
-	 */
 	public JwtValidateStatus validateToken(String token) {
 		try {
 			Jwts.parser()
@@ -100,15 +82,25 @@ public class JwtTokenProvider {
 		}
 	}
 
-	/**
-	 * 인증 정보 설정을 위한 메서드
-	 * @param token 접근 토큰
-	 * @return 인증 정보
-	 */
 	public Authentication getAuthentication(String token) {
 		Claims claims = getClaims(token);
 		User principal = new User(claims.getSubject(), "", Collections.emptyList());
 		return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+	}
+
+	/**
+	 * 블랙리스트 키로 쓰는 jti.
+	 */
+	public String getJti(String token) {
+		return getClaims(token).getId();
+	}
+
+	/**
+	 * 토큰 만료까지 남은 시간(ms). 0 이하면 이미 만료. 블랙리스트 TTL 산정에 쓴다.
+	 */
+	public long getRemainingMillis(String token) {
+		long remaining = getClaims(token).getExpiration().getTime() - System.currentTimeMillis();
+		return Math.max(remaining, 0);
 	}
 
 }

--- a/src/main/java/cat/community/nyangmunity/member/controller/AuthController.java
+++ b/src/main/java/cat/community/nyangmunity/member/controller/AuthController.java
@@ -3,73 +3,65 @@ package cat.community.nyangmunity.member.controller;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import cat.community.nyangmunity.global.exception.global.BadRequestException;
 import cat.community.nyangmunity.global.provider.CookieProvider;
+import cat.community.nyangmunity.member.response.AuthUrlResponse;
+import cat.community.nyangmunity.member.response.MemberAuthenticationResponse;
 import cat.community.nyangmunity.member.response.MemberInfoResponse;
-import cat.community.nyangmunity.member.service.AuthService;
-import lombok.RequiredArgsConstructor;
-
 import cat.community.nyangmunity.member.response.google.GoogleUserResponse;
 import cat.community.nyangmunity.member.response.kakao.KakaoUserResponse;
-
-import cat.community.nyangmunity.member.response.MemberAuthenticationResponse;
+import cat.community.nyangmunity.member.service.AuthService;
 import cat.community.nyangmunity.member.service.MemberFacadeService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
+	private static final String KAKAO = "kakao";
+	private static final String GOOGLE = "google";
+
 	private final AuthService authService;
 	private final CookieProvider cookieProvider;
 	private final MemberFacadeService memberFacadeService;
 
-	@GetMapping("/kakao/url")
-	public String requestKakaoAuthorizationUrl() {
-		return authService.requestKakaoAuthorizationUrl();
+	@GetMapping("/{provider}/url")
+	public AuthUrlResponse requestAuthorizationUrl(@PathVariable String provider) {
+		return new AuthUrlResponse(switch (provider) {
+			case KAKAO -> authService.requestKakaoAuthorizationUrl();
+			case GOOGLE -> authService.requestGoogleAuthorizationUrl();
+			default -> throw new BadRequestException("지원하지 않는 소셜 로그인 제공자입니다.");
+		});
 	}
 
-	@GetMapping("/google/url")
-	public String requestGoogleAuthorizationUrl() {
-		return authService.requestGoogleAuthorizationUrl();
-	}
-
-	@GetMapping("/kakaoLogin")
-	public ResponseEntity<MemberInfoResponse> redirectKakaoLogin(@RequestParam String code) {
-		KakaoUserResponse kakaoUserResponse = authService.loginWithKakao(code).block();
-		MemberAuthenticationResponse authenticationResponse = memberFacadeService.socialLogin("KAKAO",
-			kakaoUserResponse);
+	@GetMapping("/{provider}/callback")
+	public ResponseEntity<MemberInfoResponse> socialLoginCallback(
+		@PathVariable String provider,
+		@RequestParam String code
+	) {
+		MemberAuthenticationResponse authenticationResponse = switch (provider) {
+			case KAKAO -> {
+				KakaoUserResponse kakaoUser = authService.loginWithKakao(code).block();
+				yield memberFacadeService.socialLogin("KAKAO", kakaoUser);
+			}
+			case GOOGLE -> {
+				GoogleUserResponse googleUser = authService.loginWithGoogle(code).block();
+				yield memberFacadeService.socialLogin("GOOGLE", googleUser);
+			}
+			default -> throw new BadRequestException("지원하지 않는 소셜 로그인 제공자입니다.");
+		};
 
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, String.valueOf(
-				cookieProvider.createAccessTokenCookie(authenticationResponse.memberTokens()
-					.accessToken())
-			))
-			.header(HttpHeaders.SET_COOKIE, String.valueOf(
-				cookieProvider.createRefreshTokenCookie(authenticationResponse.memberTokens()
-					.refreshToken())
-			))
-			.body(authenticationResponse.memberInfoResponse());
-	}
-
-	@GetMapping("/googleLogin")
-	public ResponseEntity<MemberInfoResponse> redirectGoogleLogin(@RequestParam String code) {
-		GoogleUserResponse googleUserResponse = authService.loginWithGoogle(code).block();
-		MemberAuthenticationResponse authenticationResponse = memberFacadeService.socialLogin("GOOGLE",
-			googleUserResponse);
-
-		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, String.valueOf(
-				cookieProvider.createAccessTokenCookie(authenticationResponse.memberTokens()
-					.accessToken())
-			))
-			.header(HttpHeaders.SET_COOKIE, String.valueOf(
-				cookieProvider.createRefreshTokenCookie(authenticationResponse.memberTokens()
-					.refreshToken())
-			))
+			.header(HttpHeaders.SET_COOKIE,
+				cookieProvider.createAccessTokenCookie(authenticationResponse.memberTokens().accessToken()).toString())
+			.header(HttpHeaders.SET_COOKIE,
+				cookieProvider.createRefreshTokenCookie(authenticationResponse.memberTokens().refreshToken()).toString())
 			.body(authenticationResponse.memberInfoResponse());
 	}
 }

--- a/src/main/java/cat/community/nyangmunity/member/controller/MemberController.java
+++ b/src/main/java/cat/community/nyangmunity/member/controller/MemberController.java
@@ -50,8 +50,13 @@ public class MemberController {
 	}
 
 	@PostMapping("/logout")
-	private void logout(@CookieValue("refreshToken") String refreshToken) {
+	private ResponseEntity<Void> logout(@CookieValue("refreshToken") String refreshToken) {
 		memberFacadeService.logout(refreshToken);
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookieProvider.removeAccessTokenCookie().toString())
+			.header(HttpHeaders.SET_COOKIE, cookieProvider.removeRefreshTokenCookie().toString())
+			.build();
 	}
 
 	@PostMapping("/join")

--- a/src/main/java/cat/community/nyangmunity/member/controller/MemberController.java
+++ b/src/main/java/cat/community/nyangmunity/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,13 +51,23 @@ public class MemberController {
 	}
 
 	@PostMapping("/logout")
-	private ResponseEntity<Void> logout(@CookieValue("refreshToken") String refreshToken) {
-		memberFacadeService.logout(refreshToken);
+	private ResponseEntity<Void> logout(
+		@CookieValue("refreshToken") String refreshToken,
+		@RequestHeader(name = HttpHeaders.AUTHORIZATION, required = false) String authHeader
+	) {
+		memberFacadeService.logout(refreshToken, extractBearerToken(authHeader));
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookieProvider.removeAccessTokenCookie().toString())
 			.header(HttpHeaders.SET_COOKIE, cookieProvider.removeRefreshTokenCookie().toString())
 			.build();
+	}
+
+	private static String extractBearerToken(String authHeader) {
+		if (authHeader != null && authHeader.startsWith("Bearer ")) {
+			return authHeader.substring(7);
+		}
+		return null;
 	}
 
 	@PostMapping("/join")

--- a/src/main/java/cat/community/nyangmunity/member/controller/TokenController.java
+++ b/src/main/java/cat/community/nyangmunity/member/controller/TokenController.java
@@ -1,13 +1,15 @@
 package cat.community.nyangmunity.member.controller;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import cat.community.nyangmunity.global.exception.global.UnauthorizedException;
+import cat.community.nyangmunity.global.provider.CookieProvider;
 import cat.community.nyangmunity.member.response.MemberAuthenticationResponse;
+import cat.community.nyangmunity.member.response.MemberTokens;
 import cat.community.nyangmunity.member.service.TokenFacadeService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,20 +19,20 @@ import lombok.RequiredArgsConstructor;
 public class TokenController {
 
 	private final TokenFacadeService tokenFacadeService;
+	private final CookieProvider cookieProvider;
 
 	/**
-	 * 토큰 재갱신을 위한 API
-	 *
-	 * @param refreshToken 쿠키에 저장 된 refreshToken
-	 * @return 갱신된 인증 정보
+	 * 토큰 재갱신을 위한 API. 갱신된 access·refresh 토큰을 Set-Cookie 헤더로 함께 내려,
+	 * 클라이언트가 HttpOnly refresh 쿠키를 직접 조작하지 못해도 일관되게 갱신된다.
 	 */
 	@PostMapping
 	public ResponseEntity<MemberAuthenticationResponse> reissue(@CookieValue("refreshToken") String refreshToken) {
-		if (refreshToken != null) {
-			MemberAuthenticationResponse reissueResponse = tokenFacadeService.reissueToken(refreshToken);
-			return ResponseEntity.ok().body(reissueResponse);
-		}
+		MemberAuthenticationResponse reissueResponse = tokenFacadeService.reissueToken(refreshToken);
+		MemberTokens tokens = reissueResponse.memberTokens();
 
-		throw new UnauthorizedException();
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookieProvider.createAccessTokenCookie(tokens.accessToken()).toString())
+			.header(HttpHeaders.SET_COOKIE, cookieProvider.createRefreshTokenCookie(tokens.refreshToken()).toString())
+			.body(reissueResponse);
 	}
 }

--- a/src/main/java/cat/community/nyangmunity/member/entity/Token.java
+++ b/src/main/java/cat/community/nyangmunity/member/entity/Token.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 7)
+@RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 30)
 public class Token {
 
 	@Id

--- a/src/main/java/cat/community/nyangmunity/member/redisRepository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/cat/community/nyangmunity/member/redisRepository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,35 @@
+package cat.community.nyangmunity.member.redisRepository;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 로그아웃 후에도 access 토큰이 만료 전까지 살아 있는 문제를 막기 위한 블랙리스트.
+ * 키는 토큰의 jti, TTL 은 토큰 남은 만료시간만큼만 부여해 만료 후 자동 정리되게 한다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class AccessTokenBlacklistRepository {
+
+	private static final String KEY_PREFIX = "blacklist:access:";
+
+	private final StringRedisTemplate redisTemplate;
+
+	public void blacklist(String jti, long ttlMillis) {
+		if (jti == null || ttlMillis <= 0) {
+			return;
+		}
+		redisTemplate.opsForValue().set(KEY_PREFIX + jti, "1", Duration.ofMillis(ttlMillis));
+	}
+
+	public boolean isBlacklisted(String jti) {
+		if (jti == null) {
+			return false;
+		}
+		return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + jti));
+	}
+}

--- a/src/main/java/cat/community/nyangmunity/member/response/AuthUrlResponse.java
+++ b/src/main/java/cat/community/nyangmunity/member/response/AuthUrlResponse.java
@@ -1,0 +1,4 @@
+package cat.community.nyangmunity.member.response;
+
+public record AuthUrlResponse(String url) {
+}

--- a/src/main/java/cat/community/nyangmunity/member/service/MemberFacadeService.java
+++ b/src/main/java/cat/community/nyangmunity/member/service/MemberFacadeService.java
@@ -107,11 +107,12 @@ public class MemberFacadeService {
 	}
 
 	/**
-	 * 로그아웃을 위한 메서드 (토큰 제거)
-	 * @param refreshToken 갱신 토큰
+	 * 로그아웃: refresh 토큰을 Redis 화이트리스트에서 제거하고, 살아있는 access 토큰이 함께 전달된 경우
+	 * 블랙리스트에 등록해 만료 전까지 재사용을 차단한다.
 	 */
-	public void logout(String refreshToken) {
+	public void logout(String refreshToken, String accessToken) {
 		tokenFacadeService.deleteToken(refreshToken);
+		tokenFacadeService.blacklistAccessToken(accessToken);
 	}
 
 	/**

--- a/src/main/java/cat/community/nyangmunity/member/service/TokenFacadeService.java
+++ b/src/main/java/cat/community/nyangmunity/member/service/TokenFacadeService.java
@@ -2,11 +2,13 @@ package cat.community.nyangmunity.member.service;
 
 import org.springframework.stereotype.Service;
 
+import cat.community.nyangmunity.global.data.JwtValidateStatus;
 import cat.community.nyangmunity.global.exception.global.InternalServerErrorException;
 import cat.community.nyangmunity.global.exception.global.UnauthorizedException;
 import cat.community.nyangmunity.global.exception.member.LoginExpiredException;
 import cat.community.nyangmunity.global.provider.JwtTokenProvider;
 import cat.community.nyangmunity.member.entity.Token;
+import cat.community.nyangmunity.member.redisRepository.AccessTokenBlacklistRepository;
 import cat.community.nyangmunity.member.response.MemberAuthenticationResponse;
 import cat.community.nyangmunity.member.response.MemberInfoResponse;
 import cat.community.nyangmunity.member.response.MemberTokens;
@@ -18,6 +20,7 @@ public class TokenFacadeService {
 
 	private final TokenQueryService tokenQueryService;
 	private final TokenCommandService tokenCommandService;
+	private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 
 	private final JwtTokenProvider jwtTokenProvider;
 
@@ -66,6 +69,22 @@ public class TokenFacadeService {
 	public void deleteToken(String refreshToken) {
 		Token token = tokenQueryService.findTokenByRefreshToken(refreshToken);
 		tokenCommandService.delete(token);
+	}
+
+	/**
+	 * 로그아웃 시 access 토큰을 블랙리스트에 등록한다.
+	 * 이미 만료·위조된 토큰은 등록 의미가 없어 무시한다.
+	 */
+	public void blacklistAccessToken(String accessToken) {
+		if (accessToken == null) {
+			return;
+		}
+		if (jwtTokenProvider.validateToken(accessToken) != JwtValidateStatus.ACCEPTED) {
+			return;
+		}
+		String jti = jwtTokenProvider.getJti(accessToken);
+		long remaining = jwtTokenProvider.getRemainingMillis(accessToken);
+		accessTokenBlacklistRepository.blacklist(jti, remaining);
 	}
 
 	private Token validateRefreshToken(String refreshToken) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,7 @@ logging:
 # 개발 환경 변수
 nyangmunity:
   domain: localhost
+  cookie-secure: false # localhost(HTTP) 에서도 쿠키가 박히도록 dev 만 false
 jwt:
   access-token-expiration: 3600000 # 1시간
   refresh-token-expiration: 2592000000 # 30일

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,8 +27,8 @@ logging:
 nyangmunity:
   domain: localhost
 jwt:
-  access-token-expiration: 600000 # 10분
-  refresh-token-expiration: 3600000 # 1시간
+  access-token-expiration: 3600000 # 1시간
+  refresh-token-expiration: 2592000000 # 30일
 kakao:
   redirect-uri: "http://localhost:5173/auth/kakao/callback"
 google:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,8 +25,8 @@ logging:
 nyangmunity:
   domain: nyangmunity.bbgk.me
 jwt:
-  access-token-expiration: 1800000 # 30분
-  refresh-token-expiration: 7889280000 # 3달
+  access-token-expiration: 3600000 # 1시간
+  refresh-token-expiration: 2592000000 # 30일
 kakao:
   redirect-uri: "https://nyangmunity.bbgk.me/auth/kakao/callback"
 google:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,6 +24,7 @@ logging:
 # 운영 환경 변수
 nyangmunity:
   domain: nyangmunity.bbgk.me
+  cookie-secure: true
 jwt:
   access-token-expiration: 3600000 # 1시간
   refresh-token-expiration: 2592000000 # 30일


### PR DESCRIPTION
## Summary

- 환경마다 어긋나 있던 JWT 만료를 Access 1시간 / Refresh 30일 단일 기준으로 통일
- Refresh 쿠키를 HttpOnly·Secure(prod)·SameSite=Lax 로 묶고 클라이언트의 수동 쿠키 조작 제거
- 401 응답을 만료·무효 의미 코드로 분리하고 인증 실패·접근 거부 응답도 같은 형식으로 통일
- 로그아웃 시 Access 토큰을 블랙리스트에 등록해 도난 토큰 노출 창 제거
- 라우트·응답 불일치로 동작하지 않던 소셜 로그인 콜백 회복
- 새로고침 시 Access 만료만으로 자동 로그아웃되던 흐름 정정 (무효 토큰만 즉시 정리, 그 외 401 은 재발급 먼저 시도)

## 변경 폭

- 백엔드 15개 (수정·신규), 프론트 4개
- 인증 도메인 단위 테스트는 별도 PR (`test/back/auth-coverage`) 로 분리

## Test plan

- [x] `./gradlew build` 통과
- [x] Access 만료 후 새로고침 시 자동 재발급으로 세션 유지 확인
- [x] 카카오·구글 소셜 로그인 콜백 정상 동작 확인
- [x] 로그아웃 직후 같은 Access 로 인증 요청 시 즉시 거부 확인