### PR TITLE
feat: 이미지 업로드 시 사용자 제목 입력 지원

### DIFF
--- a/front-react/src/components/upload/UploadModal.tsx
+++ b/front-react/src/components/upload/UploadModal.tsx
@@ -11,6 +11,7 @@ interface Props {
   onClose: () => void;
 }
 
+const MAX_NAME = 60;
 const MAX_DESCRIPTION = 500;
 const SUGGESTED_TAGS = ['#아기냥', '#식빵자세', '#골골송', '#창문냥', '#박스고양이', '#하품'];
 
@@ -32,6 +33,7 @@ export function UploadModal({ open, onClose }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState('');
@@ -44,6 +46,7 @@ export function UploadModal({ open, onClose }: Props) {
       if (current) URL.revokeObjectURL(current);
       return null;
     });
+    setName('');
     setDescription('');
     setTags([]);
     setTagInput('');
@@ -132,6 +135,7 @@ export function UploadModal({ open, onClose }: Props) {
       await imagesApi.uploadToS3(uploadUrl, file);
       await imagesApi.completeUpload({
         imageId: id,
+        name: name.trim() || undefined,
         description: description.trim() || undefined,
         tags: tags.length > 0 ? tags : undefined,
       });
@@ -249,6 +253,24 @@ export function UploadModal({ open, onClose }: Props) {
             </section>
 
             <section className="up-form nm-scroll">
+              <div className="up-field">
+                <label className="up-label" htmlFor="up-name">
+                  제목 <span className="up-label-opt">선택</span>
+                </label>
+                <input
+                  id="up-name"
+                  type="text"
+                  className="up-input"
+                  maxLength={MAX_NAME}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={file?.name ?? '이 사진을 부를 이름'}
+                />
+                <span className="up-counter">
+                  {MAX_NAME - name.length} / {MAX_NAME}
+                </span>
+              </div>
+
               <div className="up-field">
                 <label className="up-label" htmlFor="up-tags">
                   태그 <span className="up-label-opt">선택 · 최대 10개</span>

--- a/front-react/src/styles/upload.css
+++ b/front-react/src/styles/upload.css
@@ -244,6 +244,7 @@
     border-style: solid;
   }
 
+  .up-input,
   .up-textarea {
     padding: 10px 12px;
     border-radius: var(--r-2);
@@ -251,15 +252,19 @@
     background: var(--bg-surface);
     font: 400 14px var(--font-kr);
     color: var(--text-primary);
-    resize: vertical;
     outline: none;
     width: 100%;
     line-height: 1.55;
   }
+  .up-textarea {
+    resize: vertical;
+  }
+  .up-input:focus,
   .up-textarea:focus {
     border-color: var(--accent-hover);
     box-shadow: 0 0 0 3px var(--accent-subtle);
   }
+  .up-input::placeholder,
   .up-textarea::placeholder { color: var(--text-tertiary); }
   .up-counter {
     align-self: flex-end;

--- a/front-react/src/types/index.ts
+++ b/front-react/src/types/index.ts
@@ -86,6 +86,7 @@ export interface UploadUrlResponse {
 
 export interface ImageUploadCompleteRequest {
   imageId: string;
+  name?: string;
   description?: string;
   tags?: string[];
 }

--- a/src/main/java/cat/community/nyangmunity/postImage/image/entity/Image.java
+++ b/src/main/java/cat/community/nyangmunity/postImage/image/entity/Image.java
@@ -173,6 +173,13 @@ public class Image {
 	}
 
 	/**
+	 * 사용자가 입력한 제목으로 갱신합니다. 빈 값이면 기존 파일명을 유지합니다.
+	 */
+	public void updateName(String name) {
+		this.name = name;
+	}
+
+	/**
 	 * 업로더(회원)를 설정합니다.
 	 */
 	public void setMember(Member member) {

--- a/src/main/java/cat/community/nyangmunity/postImage/image/request/ImageUploadRequest.java
+++ b/src/main/java/cat/community/nyangmunity/postImage/image/request/ImageUploadRequest.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 public class ImageUploadRequest {
 
   private String imageId;
+  private String name;
   private String description;
   private List<String> tags;
 }

--- a/src/main/java/cat/community/nyangmunity/postImage/image/service/ImageCommandService.java
+++ b/src/main/java/cat/community/nyangmunity/postImage/image/service/ImageCommandService.java
@@ -66,6 +66,11 @@ public class ImageCommandService {
 		// 업로더 설정
 		image.setMember(member);
 
+		// 제목 업데이트 (비어있으면 createImageInfo 단계에서 박힌 원본 파일명 유지)
+		if (request.getName() != null && !request.getName().trim().isEmpty()) {
+			image.updateName(request.getName().trim());
+		}
+
 		// 설명 업데이트
 		if (request.getDescription() != null && !request.getDescription().trim().isEmpty()) {
 			image.updateDescription(request.getDescription());


### PR DESCRIPTION
- 업로드 모달에 선택형 제목 필드 추가, 비워두면 원본 파일명을 그대로 유지
- 업로드 완료 요청이 제목 값을 수용해 빈 값이 아닐 때만 갱신

## Test plan

- [x] `./gradlew compileJava` 통과
- [x] `tsc -b --noEmit` 통과
- [x] 제목 입력 후 업로드 → 상세 페이지에서 제목 노출 확인
- [x] 제목 비워둔 채 업로드 → 파일명 유지 확인
- [x] placeholder 가 선택된 파일명으로 표시되는지 확인